### PR TITLE
Fix GitHub Pages 404 Error Documentation

### DIFF
--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -23,18 +23,52 @@ GitHub Pages (gh-pages branch)
 https://docs.screener.kr
 ```
 
+## Quick Start
+
+**First-time setup** (one-time configuration):
+
+1. **Enable GitHub Pages**:
+   - Go to https://github.com/kcenon/screener_system/settings/pages
+   - Source: Select **"GitHub Actions"**
+   - Save
+
+2. **Trigger First Deployment**:
+   ```bash
+   # Manually trigger workflow
+   gh workflow run docs.yml
+
+   # Or push any documentation change
+   git commit --allow-empty -m "docs: initial deployment"
+   git push origin main
+   ```
+
+3. **Verify**:
+   - Check Actions tab: https://github.com/kcenon/screener_system/actions
+   - Wait ~5 minutes
+   - Visit: https://kcenon.github.io/screener_system
+
+**After setup**: Documentation automatically deploys on every push to `main` branch that affects documentation files.
+
+---
+
 ## Deployment Configuration
 
 ### 1. GitHub Pages Settings
 
 #### Enable GitHub Pages
 
+**IMPORTANT**: For GitHub Actions-based deployment, you must select "GitHub Actions" as the source, NOT "Deploy from a branch".
+
 1. Navigate to repository **Settings** → **Pages**
+   - URL: https://github.com/kcenon/screener_system/settings/pages
 2. Configure the following:
-   - **Source**: Deploy from a branch
-   - **Branch**: `gh-pages`
-   - **Folder**: `/` (root)
-   - **Enforce HTTPS**: ✅ Enabled
+   - **Source**: **GitHub Actions** ⚠️ (NOT "Deploy from a branch")
+   - **Enforce HTTPS**: ✅ Enabled (automatically enabled)
+
+**Why GitHub Actions?**
+- Our deployment workflow (`.github/workflows/docs.yml`) uses GitHub Actions to build and deploy
+- Selecting "Deploy from a branch" will cause deployment failures
+- GitHub Actions provides more control over build process (Sphinx + TypeDoc + Docusaurus)
 
 #### Custom Domain Setup
 
@@ -236,11 +270,43 @@ themeConfig: {
 
 ### Common Issues
 
-#### Issue: 404 errors after deployment
-**Symptoms**: Site shows 404 or pages not found
+#### Issue: GitHub Pages returns 404 error
+**Symptoms**: Site shows "404 - File not found" at https://kcenon.github.io/screener_system
+
+**Root Cause**: GitHub Pages is not enabled in repository settings
 
 **Solutions**:
-1. Check `baseUrl` in `docusaurus.config.ts` matches deployment path (`/` for custom domain)
+1. **Enable GitHub Pages** (REQUIRED):
+   - Go to https://github.com/kcenon/screener_system/settings/pages
+   - Under "Build and deployment" → "Source"
+   - Select **"GitHub Actions"** (NOT "Deploy from a branch")
+   - Save settings
+
+2. **Trigger Deployment**:
+   ```bash
+   # Option 1: Manually trigger workflow
+   gh workflow run docs.yml
+
+   # Option 2: Make a commit to trigger auto-deployment
+   git commit --allow-empty -m "Trigger documentation deployment"
+   git push origin main
+   ```
+
+3. **Verify Deployment**:
+   - Check workflow status: https://github.com/kcenon/screener_system/actions/workflows/docs.yml
+   - Wait 3-5 minutes for deployment to complete
+   - Visit https://kcenon.github.io/screener_system
+
+**Expected Timeline**:
+- Configuration change: < 1 minute
+- Workflow run: 3-5 minutes
+- Total: ~5 minutes
+
+#### Issue: 404 errors after deployment (pages not found)
+**Symptoms**: Site loads but individual pages show 404
+
+**Solutions**:
+1. Check `baseUrl` in `docusaurus.config.ts` matches deployment path (`/` for custom domain, `/screener_system/` for GitHub Pages)
 2. Verify CNAME file exists in build output: `docs-site/build/CNAME`
 3. Check GitHub Pages settings shows correct custom domain
 4. Wait 5-10 minutes for cache to clear
@@ -249,7 +315,7 @@ themeConfig: {
 # Verify build output
 ls docs-site/build/CNAME
 cat docs-site/build/CNAME
-# Should show: docs.screener.kr
+# Should show: docs.screener.kr (or empty if using GitHub Pages default URL)
 ```
 
 #### Issue: SSL certificate not working

--- a/docs/kanban/todo/BUGFIX-012.md
+++ b/docs/kanban/todo/BUGFIX-012.md
@@ -1,0 +1,161 @@
+# BUGFIX-012: Fix GitHub Pages 404 Error
+
+**Status**: IN_PROGRESS
+**Priority**: High
+**Assignee**: Claude Code
+**Estimated Time**: 1-2 hours
+**Sprint**: Post-MVP (Infrastructure)
+**Tags**: #bugfix #documentation #github-pages #infrastructure
+**Branch**: bugfix/BUGFIX-012-github-pages-404
+
+## Description
+
+The documentation site at https://kcenon.github.io/screener_system is returning a 404 error because GitHub Pages is not properly configured in the repository settings. While the documentation build workflow is running successfully (last 5 runs all successful), the deployment step is being skipped because Pages is not enabled.
+
+## Root Cause Analysis
+
+1. **GitHub Pages Not Enabled**: API check confirms Pages is not configured
+   ```bash
+   gh api repos/kcenon/screener_system/pages
+   # Returns: 404 Not Found
+   ```
+
+2. **Workflow Running Successfully**: Documentation builds are completing without errors
+   - Latest run: 5m11s, completed successfully on 2025-11-15
+   - Build artifacts created in `docs-site/build`
+   - Deployment step skipped due to Pages not configured
+
+3. **Configuration Exists**: `docusaurus.config.ts` is correctly configured
+   - url: `https://kcenon.github.io`
+   - baseUrl: `/screener_system/`
+   - deploymentBranch: `gh-pages`
+
+## Subtasks
+
+- [ ] Enable GitHub Pages in repository settings
+  - [ ] Navigate to https://github.com/kcenon/screener_system/settings/pages
+  - [ ] Under "Build and deployment" → "Source"
+  - [ ] Select **GitHub Actions** (NOT "Deploy from a branch")
+  - [ ] Save settings
+- [ ] Manually trigger documentation workflow
+  - [ ] Go to Actions tab
+  - [ ] Select "Deploy Documentation to GitHub Pages" workflow
+  - [ ] Click "Run workflow" → "Run workflow"
+- [ ] Verify deployment
+  - [ ] Wait for workflow to complete (~3-5 minutes)
+  - [ ] Check https://kcenon.github.io/screener_system
+  - [ ] Verify all pages load correctly
+  - [ ] Test navigation and links
+- [x] Update documentation
+  - [x] Document GitHub Pages setup in `docs/DEPLOYMENT_GUIDE.md`
+  - [x] Add troubleshooting section for 404 errors
+  - [x] Add Quick Start section for first-time setup
+  - [x] Update GitHub Pages Settings section with GitHub Actions configuration
+
+## Acceptance Criteria
+
+- [ ] GitHub Pages is enabled in repository settings
+- [ ] Source is set to "GitHub Actions"
+- [ ] Documentation workflow completes successfully with deployment
+- [ ] https://kcenon.github.io/screener_system loads without 404 error
+- [ ] All documentation pages are accessible
+- [ ] Navigation and links work correctly
+- [ ] Setup instructions added to deployment guide
+
+## Technical Details
+
+### Current Workflow Configuration
+- **File**: `.github/workflows/docs.yml`
+- **Trigger**: Push to main (docs/, frontend/, backend/, docs-site/ paths)
+- **Build Steps**:
+  1. Build Sphinx documentation (Python API)
+  2. Generate TypeDoc documentation (Frontend)
+  3. Build Docusaurus site
+  4. Upload Pages artifact
+  5. Deploy to GitHub Pages (currently skipped)
+
+### Expected Behavior After Fix
+1. Workflow runs on push to main
+2. All documentation builds successfully
+3. Artifact uploaded to GitHub Pages
+4. Deployment completes successfully
+5. Site available at https://kcenon.github.io/screener_system
+
+## Dependencies
+
+- None (this is a configuration issue, not a code issue)
+
+## Blocks
+
+- None currently blocked by this issue
+
+## References
+
+- GitHub Pages Documentation: https://docs.github.com/en/pages
+- Docusaurus Deployment: https://docusaurus.io/docs/deployment#deploying-to-github-pages
+- Workflow File: `.github/workflows/docs.yml`
+- Docusaurus Config: `docs-site/docusaurus.config.ts`
+
+## Progress
+
+**Percentage Complete**: 50%
+
+**Completed Work**:
+- ✅ Created branch: `bugfix/BUGFIX-012-github-pages-404`
+- ✅ Updated `docs/DEPLOYMENT_GUIDE.md`:
+  - Added Quick Start section for first-time setup
+  - Updated GitHub Pages Settings section (GitHub Actions vs Deploy from a branch)
+  - Added comprehensive troubleshooting for GitHub Pages 404 error
+  - Clarified difference between initial 404 and page-specific 404s
+
+**Remaining Work**:
+- ⏳ User must manually enable GitHub Pages in repository settings (requires admin access)
+- ⏳ Trigger workflow and verify deployment
+- ⏳ Create PR and merge changes
+
+## Notes
+
+### Why This Happened
+- GitHub Pages needs to be manually enabled in repository settings
+- Cannot be configured via GitHub Actions workflow alone
+- Common oversight when setting up new documentation
+
+### Impact
+- **User Impact**: High - Documentation is inaccessible to users
+- **Developer Impact**: Medium - Internal docs still available in repository
+- **SEO Impact**: High - Documentation not indexed by search engines
+
+### Quick Fix Steps (Manual)
+1. Go to: https://github.com/kcenon/screener_system/settings/pages
+2. Source: Select "GitHub Actions"
+3. Save
+4. Actions → "Deploy Documentation to GitHub Pages" → "Run workflow"
+5. Wait ~5 minutes
+6. Visit: https://kcenon.github.io/screener_system
+
+### Verification Checklist
+- [ ] Homepage loads
+- [ ] Navigation menu works
+- [ ] API Reference section accessible
+- [ ] Getting Started guide accessible
+- [ ] Architecture documentation accessible
+- [ ] Blog/Changelog accessible
+- [ ] External links work (GitHub, issues)
+- [ ] Dark mode toggle works
+- [ ] Search functionality works
+
+## Related Tickets
+
+- DOC-001: Documentation platform setup (completed)
+- INFRA-002: CI/CD Pipeline with GitHub Actions (completed)
+
+## Time Tracking
+
+- **Estimated**: 1-2 hours
+- **Actual**: 0.75 hours (in progress)
+- **Breakdown**:
+  - Analysis: 0.5 hours (completed)
+  - Documentation: 0.25 hours (completed)
+  - Configuration: Pending (user action required)
+  - Deployment trigger: Pending
+  - Verification: Pending


### PR DESCRIPTION
## Summary

Fixes BUGFIX-012: Update deployment documentation to resolve GitHub Pages 404 errors.

The documentation site at https://kcenon.github.io/screener_system returns 404 because GitHub Pages is not properly configured. This PR updates the deployment guide with correct setup instructions.

## Changes

### Documentation Updates

**Added Quick Start Section**:
- Step-by-step first-time setup instructions
- Clear explanation of GitHub Actions vs "Deploy from a branch"
- Estimated timeline for deployment (< 5 minutes)

**Updated GitHub Pages Settings Section**:
- ⚠️ **CRITICAL**: Changed from "Deploy from a branch" to "GitHub Actions"
- Added rationale for GitHub Actions (Sphinx + TypeDoc + Docusaurus build process)
- Included direct link to settings page

**Enhanced Troubleshooting**:
- Added dedicated section for GitHub Pages 404 errors
- Separated initial 404 (Pages not enabled) from page-specific 404s
- Provided multiple deployment trigger options
- Added verification steps and timeline

### Ticket Updates

**BUGFIX-012 Status**:
- Status: TODO → IN_PROGRESS
- Progress: 0% → 50%
- Assignee: TBD → Claude Code
- Marked documentation subtasks as completed

## Impact

**Before**: Users encounter 404 error with no clear resolution path
**After**: 
- Clear setup instructions in Quick Start section
- Comprehensive troubleshooting guide
- Estimated 5-minute resolution time
- Reduced support burden

## Testing

- ✅ Documentation changes reviewed
- ✅ Links verified (GitHub settings, Actions, workflow)
- ✅ Formatting validated (Markdown lint)
- ⏳ **Pending**: User must manually enable GitHub Pages (requires admin access)
- ⏳ **Pending**: Workflow trigger and deployment verification

## Next Steps

**For Repository Admin**:
1. Enable GitHub Pages:
   - Go to https://github.com/kcenon/screener_system/settings/pages
   - Source: Select "GitHub Actions"
   - Save
2. Trigger workflow:
   ```bash
   gh workflow run docs.yml
   ```
3. Verify deployment (~5 minutes):
   - https://kcenon.github.io/screener_system

## Acceptance Criteria

- [x] Quick Start section added to DEPLOYMENT_GUIDE.md
- [x] GitHub Pages Settings section updated with GitHub Actions
- [x] Troubleshooting section enhanced with 404 error resolution
- [x] BUGFIX-012 ticket updated with progress
- [ ] GitHub Pages enabled in repository settings (user action)
- [ ] Documentation site accessible at https://kcenon.github.io/screener_system

## Related Issues

- Fixes #BUGFIX-012
- Related: DOC-001 (Documentation platform setup)
- Related: INFRA-002 (CI/CD Pipeline)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] Documentation follows project guidelines
- [x] Changes are clear and concise
- [x] Links are valid and accessible
- [x] Commit message follows conventional commits format
- [x] Ticket status updated
- [x] No code changes (documentation only)