### PR TITLE
fix(security): add bcrypt 5.0 compatibility and fix starlette vulnerability

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -85,9 +85,15 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
     Returns:
         True if password matches
     """
+    # bcrypt has a 72-byte limit; truncate for bcrypt 5.0+ compatibility
+    password_bytes = plain_password.encode("utf-8")[:72]
     return bcrypt.checkpw(
-        plain_password.encode('utf-8'),
-        hashed_password.encode('utf-8') if isinstance(hashed_password, str) else hashed_password
+        password_bytes,
+        (
+            hashed_password.encode("utf-8")
+            if isinstance(hashed_password, str)
+            else hashed_password
+        ),
     )
 
 
@@ -100,10 +106,16 @@ def get_password_hash(password: str) -> str:
 
     Returns:
         Hashed password (as string)
+
+    Note:
+        bcrypt has a 72-byte limit. Passwords longer than 72 bytes are truncated
+        to maintain compatibility with bcrypt 5.0+ which enforces this limit.
     """
+    # bcrypt has a 72-byte limit; truncate for bcrypt 5.0+ compatibility
+    password_bytes = password.encode("utf-8")[:72]
     salt = bcrypt.gensalt(rounds=BCRYPT_ROUNDS)
-    hashed = bcrypt.hashpw(password.encode('utf-8'), salt)
-    return hashed.decode('utf-8')
+    hashed = bcrypt.hashpw(password_bytes, salt)
+    return hashed.decode("utf-8")
 
 
 def decode_token(token: str) -> Dict[str, Any]:

--- a/backend/tests/core/test_security.py
+++ b/backend/tests/core/test_security.py
@@ -347,12 +347,17 @@ class TestPasswordHashing:
         assert verify_password(password, hashed)
 
     def test_hash_password_very_long(self):
-        """Test hashing very long password"""
-        # Bcrypt has 72-byte limit, but our implementation should handle it
+        """Test hashing very long password (bcrypt 72-byte limit)"""
+        # bcrypt has 72-byte limit; our implementation truncates to 72 bytes
         long_password = "a" * 100
         hashed = get_password_hash(long_password)
 
+        # Verify full password works (both truncated internally to 72 bytes)
         assert verify_password(long_password, hashed)
+
+        # Verify truncated password (first 72 bytes) also works
+        truncated_password = "a" * 72
+        assert verify_password(truncated_password, hashed)
 
     def test_hash_uses_correct_rounds(self):
         """Test that hash uses configured bcrypt rounds"""

--- a/data_pipeline/requirements.txt
+++ b/data_pipeline/requirements.txt
@@ -5,6 +5,10 @@
 # Airflow 3.1.2 fixes werkzeug and flask-appbuilder vulnerabilities
 apache-airflow[postgres,celery]==3.1.2  # Security: Latest stable, fixes werkzeug & flask-appbuilder CVEs
 
+# Security: Override Airflow's transitive starlette dependency
+# Airflow pulls starlette 0.48.0 which has HTTP Range DoS vulnerability (GHSA-7f5h-v6xp-fcq8)
+starlette>=0.49.1  # Security: Fixed HTTP Range DoS (GHSA-7f5h-v6xp-fcq8, CVE-2025-62727)
+
 # Database Drivers
 # =============================================================================
 asyncpg==0.30.0  # Async PostgreSQL driver


### PR DESCRIPTION
## Summary
- Add 72-byte password truncation for bcrypt 5.0+ compatibility
- Fix data_pipeline starlette transitive dependency vulnerability

## Changes
- **backend/app/core/security.py**: Truncate passwords to 72 bytes in `get_password_hash` and `verify_password` to support bcrypt 5.0+ which enforces the 72-byte limit (previously it silently truncated)
- **backend/tests/core/test_security.py**: Update `test_hash_password_very_long` to verify the truncation behavior
- **data_pipeline/requirements.txt**: Add `starlette>=0.49.1` to override Airflow's vulnerable transitive dependency (GHSA-7f5h-v6xp-fcq8, CVE-2025-62727)

## Test plan
- [x] Backend tests should pass with bcrypt 5.0
- [x] Data pipeline security audit should pass (no starlette vulnerability)
- [ ] Run CI to verify all checks pass