### PR TITLE
docs(kanban): update README to reflect Quality Sprint completion

### DIFF
--- a/docs/kanban/README.md
+++ b/docs/kanban/README.md
@@ -59,10 +59,10 @@ Each ticket follows this structure:
 
 ## Current Ticket Distribution
 
-### ✅ Done (86 tickets)
+### ✅ Done (89 tickets)
 **Completed and verified**
 
-🎉 **MAJOR MILESTONE: MVP + Post-MVP + Freemium + Portfolio Management + OAuth + Subscription Complete!** - All core features delivered plus quality improvements, user acquisition features, full portfolio management system, OAuth social login, and subscription billing system!
+🎉 **MAJOR MILESTONE: MVP + Post-MVP + Freemium + Portfolio Management + OAuth + Subscription + Quality Sprint Complete!** - All core features delivered plus quality improvements, user acquisition features, full portfolio management system, OAuth social login, subscription billing system, and comprehensive test coverage improvements!
 
 All Sprint 1, 2, and 3 work has been successfully completed! These tickets have been fully implemented, tested, and reviewed:
 
@@ -229,7 +229,7 @@ All Sprint 1, 2, and 3 work has been successfully completed! These tickets have 
   - Expected impact: +1,500% conversion rate, +500% organic traffic
   - PR #102 merged
 
-**Bug Fixes (2 tickets):**
+**Bug Fixes (5 tickets):**
 - **BUGFIX-001**: Fix Critical Issues from Code Review (Critical, 2h actual) ✅
   - Fixed Redis health check authentication
   - Removed NGINX CORS header duplication
@@ -240,6 +240,23 @@ All Sprint 1, 2, and 3 work has been successfully completed! These tickets have 
   - 45% performance improvement (400ms → 220ms)
   - Single table scan instead of two
   - PR #24 merged
+
+- **BUGFIX-013**: Add Missing OrderBook Component Tests (High, 4h actual) ✅
+  - 90 new tests added for OrderBook component
+  - useOrderBook hook: 94.59% coverage
+  - OrderBook.tsx: 98.38% coverage
+  - PR #181 merged
+
+- **BUGFIX-014**: Complete Freemium Integration for Stock Detail (High, 1h actual) ✅
+  - StockDetailPage integrated with freemium access control
+  - FinancialsTab and TechnicalTab gated for public users
+  - PR #180 merged
+
+- **BUGFIX-015**: Increase Backend Test Coverage to 80% (High, 8h actual) ✅
+  - 150+ new backend tests added
+  - Coverage increased from 47% to 80% target
+  - All zero-coverage modules now tested
+  - PR #182 merged
 
 **Security (1 ticket):**
 - **SECURITY-001**: Fix SQL Injection Vulnerabilities (Critical, 4h actual) ✅
@@ -312,12 +329,15 @@ All Sprint 1, 2, and 3 work has been successfully completed! These tickets have 
   - 🚀 **Production Ready**: CI/CD, monitoring, logging, error handling, documentation complete
   - 🎯 **User Acquisition Ready**: Freemium model with expected +1,500% conversion rate improvement
 
-**🚀 POST-MVP ENHANCEMENTS** (17 additional tickets completed):
+**🚀 POST-MVP ENHANCEMENTS** (20 additional tickets completed):
 
-**Bug Fixes & Quality Assurance (7 tickets):**
+**Bug Fixes & Quality Assurance (10 tickets):**
 - **BUGFIX-003 to BUGFIX-006**: Critical runtime validation and documentation fixes ✅
 - **BUGFIX-008, BUGFIX-009**: Performance testing and CI/CD validation ✅
 - **BUGFIX-011**: Acceptance criteria validation across all tickets ✅
+- **BUGFIX-013**: Add Missing OrderBook Component Tests (PR #181) ✅
+- **BUGFIX-014**: Complete Freemium Integration for Stock Detail (PR #180) ✅
+- **BUGFIX-015**: Increase Backend Test Coverage to 80% (PR #182) ✅
 
 **Documentation Sprint (9 tickets):**
 - **DOC-001**: Documentation platform setup with Docusaurus ✅
@@ -346,24 +366,19 @@ All Sprint 1, 2, and 3 work has been successfully completed! These tickets have 
   - **Total Feature Effort**: 42 hours (17h frontend + 25h backend)
   - **Impact**: Core value proposition, +40% user retention expected
 
-**📊 Total Project Completion**: 58 tickets, ~387+ hours across all phases
+**📊 Total Project Completion**: 89 tickets, ~400+ hours across all phases
 
 ---
 
 ### 📋 Todo (0 tickets)
 **Ready to start, prioritized**
 
-No tickets currently in Todo. Move tickets from Backlog when ready to start.
-
-**Available in Backlog** (3 new BUGFIX tickets):
-- **BUGFIX-013**: Add Missing OrderBook Component Tests (6h) - FE-005 tests
-- **BUGFIX-014**: Complete Freemium Integration for Stock Detail (3h) - FE-012 gaps
-- **BUGFIX-015**: Increase Backend Test Coverage to 80% (16h) - Currently 47%
+No tickets currently in Todo. All planned work has been completed.
 
 **Next Steps**:
-- Review and prioritize new BUGFIX tickets
-- Address test coverage gaps
-- Complete freemium integration
+- Review backlog for future enhancements (UI/UX improvements)
+- Gather user feedback for new feature requests
+- Plan Sprint 5 based on production usage data
 
 ---
 
@@ -374,35 +389,29 @@ No tickets currently in review.
 
 ---
 
-### Backlog (Post-Sprint 4)
-**Status: Sprint 5 - Quality & Testing Focus**
+### Backlog (Post-Sprint 5)
+**Status: All Quality Sprint Tickets Complete**
 
-⚠️ **Gap Analysis Results** (2025-11-26):
-Comprehensive ticket review revealed implementation gaps despite "DONE" status.
+✅ **Gap Analysis Resolution** (2025-11-27):
+All identified implementation gaps have been resolved.
 
-**New BUGFIX Tickets** (3 tickets, 25h total):
-- 🔴 **BUGFIX-013**: Add Missing OrderBook Component Tests (6h)
-  - FE-005 marked DONE but all tests pending
-  - OrderBook.tsx (350+ lines) has 0% test coverage
-  - useOrderBook.ts (220+ lines) has 0% test coverage
-  - **Impact**: Critical real-time feature untested
+**Completed Quality Sprint Tickets** (3 tickets, 13h total):
+- ✅ **BUGFIX-013**: Add Missing OrderBook Component Tests (4h actual)
+  - 90 tests added, 94-98% coverage achieved
+  - PR #181 merged
 
-- 🔴 **BUGFIX-014**: Complete Freemium Integration for Stock Detail (3h)
-  - FE-012 infrastructure complete (100%), but Stock Detail integration (0%)
-  - FinancialsTab, TechnicalTab not gated for public users
-  - Public users can access premium content
-  - **Impact**: Revenue leakage, inconsistent UX
+- ✅ **BUGFIX-014**: Complete Freemium Integration for Stock Detail (1h actual)
+  - StockDetailPage fully integrated with freemium access control
+  - PR #180 merged
 
-- 🔴 **BUGFIX-015**: Increase Backend Test Coverage to 80% (16h)
-  - Current coverage: 47.05% (target: 80%)
-  - 4 modules with 0% coverage
-  - Many services/repositories below 25%
-  - **Impact**: Quality risk, regression potential
+- ✅ **BUGFIX-015**: Increase Backend Test Coverage to 80% (8h actual)
+  - 150+ new tests, coverage target achieved
+  - PR #182 merged
 
-**Previous Sprint 4 (Complete)**:
-- ✅ BUGFIX-006, 007, 008, 009, 010, 011, 012 - All DONE
+**Sprint 4 & 5 (Complete)**:
+- ✅ BUGFIX-006 to BUGFIX-015 - All DONE
 - ✅ All P0/P1 features implemented
-- ✅ 86 tickets completed
+- ✅ 89 tickets completed
 
 **Note**: IMPROVEMENT-002~006 and TEST-001~010 tickets already in `done/` folder.
 
@@ -671,21 +680,29 @@ Each team member answers:
 
 ## Recent Updates
 
-**2025-11-26 (Latest - GAP ANALYSIS & NEW BUGFIX TICKETS)**: 🔍📋
+**2025-11-27 (Latest - QUALITY SPRINT COMPLETE!)**: ✅🎉
+- 🏆 **All Quality Sprint Tickets Completed**:
+  - ✅ **BUGFIX-013**: OrderBook tests (90 tests, 94-98% coverage) - PR #181
+  - ✅ **BUGFIX-014**: Freemium Stock Detail integration - PR #180
+  - ✅ **BUGFIX-015**: Backend test coverage increased to 80% (150+ tests) - PR #182
+- 📊 **Project Statistics**:
+  - Done: 89 tickets (100% of all planned work)
+  - Todo: 0 tickets
+  - Total effort: ~400+ hours across all phases
+- 🎯 **Achievements**:
+  - All identified implementation gaps resolved
+  - Test coverage targets met
+  - Production-ready quality
+
+**2025-11-26 (GAP ANALYSIS & BUGFIX TICKETS CREATED)**: 🔍📋
 - 🔍 **Comprehensive Gap Analysis**: Reviewed all 86 done tickets for implementation gaps
   - Analyzed subtasks, acceptance criteria, and actual code implementation
   - Found 3 significant gaps despite "DONE" status
-  - Created 3 new BUGFIX tickets (25h total effort)
-- 🆕 **New Tickets Created**:
-  - **BUGFIX-013**: OrderBook tests missing (FE-005) - 6h
-  - **BUGFIX-014**: Freemium Stock Detail integration missing (FE-012) - 3h
-  - **BUGFIX-015**: Backend test coverage 47% vs 80% target - 16h
-- 📊 **Key Findings**:
-  - FE-005: Component implemented but 0% test coverage
-  - FE-012: Infrastructure 100% complete, Stock Detail 0% integrated
-  - Backend: 47.05% coverage (33% below 80% target)
-  - DB-003: Fully implemented - no blocking issues
-- 📁 **Backlog Updated**: 3 new tickets in `backlog/` folder
+  - Created 3 new BUGFIX tickets (25h estimated, 13h actual)
+- 🆕 **Tickets Created** (All now completed):
+  - **BUGFIX-013**: OrderBook tests missing (FE-005)
+  - **BUGFIX-014**: Freemium Stock Detail integration missing (FE-012)
+  - **BUGFIX-015**: Backend test coverage 47% vs 80% target
 
 **2025-11-26 (KANBAN CLEANUP)**: 📋✨
 - 🔄 **Kanban Board Cleanup**: Updated ticket counts and status
@@ -888,7 +905,7 @@ Each team member answers:
 
 ---
 
-Last Updated: 2025-11-26 (KANBAN CLEANUP - 86 tickets done, 0 todo, OAuth + Subscription complete! 🎉✨)
+Last Updated: 2025-11-27 (QUALITY SPRINT COMPLETE - 89 tickets done, 0 todo, All gaps resolved! ✅🎉)
 
 ---
 


### PR DESCRIPTION
## Summary

- Update Kanban README.md to accurately reflect the completion of BUGFIX-013, 014, and 015
- Sync documentation with actual repository state (all three PRs already merged)

## Changes

- **Ticket Counts**: Updated Done count from 86 → 89
- **Bug Fixes Section**: Added BUGFIX-013, 014, 015 with completion details and PR references
- **Post-MVP Section**: Updated from 17 → 20 additional tickets completed
- **Total Completion**: Updated to 89 tickets, ~400+ hours
- **Backlog Section**: Removed outdated "gap analysis" content, marked Quality Sprint complete
- **Recent Updates**: Added 2025-11-27 Quality Sprint completion entry
- **Last Updated**: Updated timestamp

## Why This Change

The README.md was showing outdated information:
- Listed BUGFIX-013, 014, 015 as backlog items (they're done)
- Showed 86 tickets (actual: 89)
- Gap analysis section was misleading (gaps are now resolved)

## Test Plan

- [x] Verify markdown formatting renders correctly
- [x] Confirm all PR numbers match actual merged PRs (#180, #181, #182)
- [x] Check ticket counts are accurate