### PR TITLE
feat(infra): implement CD pipeline with SSH+Docker Compose deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,169 +12,269 @@ on:
         options:
           - staging
           - production
+      image_tag:
+        description: 'Docker image tag to deploy (default: latest commit SHA)'
+        required: false
+        type: string
 
 permissions:
   contents: read
   packages: read
 
+env:
+  REGISTRY: ghcr.io
+  BACKEND_IMAGE: ghcr.io/${{ github.repository }}/backend
+  FRONTEND_IMAGE: ghcr.io/${{ github.repository }}/frontend
+
 jobs:
+  # ==========================================================================
+  # STAGING DEPLOYMENT
+  # ==========================================================================
   deploy-staging:
     name: Deploy to Staging
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'staging')
     environment:
       name: staging
-      url: https://staging.screener.example.com
+      url: ${{ vars.STAGING_URL || 'https://staging.screener.example.com' }}
+    concurrency:
+      group: deploy-staging
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
+            echo "tag=${{ github.event.inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Copy deployment files to staging server
+        uses: appleboy/scp-action@v0.1.7
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          source: "docker-compose.staging.yml,scripts/deploy.sh,infrastructure/nginx/"
+          target: "~/screener"
+          overwrite: true
 
-      - name: Pull latest Docker images
-        run: |
-          docker pull ghcr.io/${{ github.repository }}/backend:latest
-          docker pull ghcr.io/${{ github.repository }}/frontend:latest
-
-      - name: Verify images
-        run: |
-          echo "✓ Backend image pulled successfully"
-          docker inspect ghcr.io/${{ github.repository }}/backend:latest --format='Image ID: {{.Id}}, Created: {{.Created}}'
-          echo ""
-          echo "✓ Frontend image pulled successfully"
-          docker inspect ghcr.io/${{ github.repository }}/frontend:latest --format='Image ID: {{.Id}}, Created: {{.Created}}'
-
-      - name: Deploy to staging
-        run: |
-          echo "✓ Images verified and ready for deployment"
-          echo "Note: Actual deployment commands are disabled (placeholder)"
-          # Add actual deployment commands here when ready:
-          # docker-compose -f docker-compose.staging.yml up -d
-
-      - name: Run smoke tests
-        run: |
-          echo "Running smoke tests..."
-          sleep 10
-          # Add smoke test commands
-          # curl -f https://staging.screener.example.com/health || exit 1
-
-      - name: Notify on Slack
-        if: false  # Disabled: SLACK_WEBHOOK_URL not configured
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "text": "Staging Deployment ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Staging Deployment ${{ job.status }}*\n\nCommit: ${{ github.sha }}\nAuthor: ${{ github.actor }}"
-                  }
-                }
-              ]
-            }
+      - name: Deploy to staging via SSH
+        uses: appleboy/ssh-action@v1.2.0
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          REGISTRY: ${{ env.REGISTRY }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          envs: IMAGE_TAG,REGISTRY,BACKEND_IMAGE,FRONTEND_IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
+          script_stop: true
+          script: |
+            cd ~/screener
+            chmod +x scripts/deploy.sh
+            ./scripts/deploy.sh \
+              --environment staging \
+              --image-tag "$IMAGE_TAG" \
+              --registry "$REGISTRY" \
+              --backend-image "$BACKEND_IMAGE" \
+              --frontend-image "$FRONTEND_IMAGE" \
+              --github-token "$GITHUB_TOKEN" \
+              --github-actor "$GITHUB_ACTOR"
 
+      - name: Verify deployment health
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            echo "Running post-deployment health checks..."
+            MAX_RETRIES=10
+            RETRY_INTERVAL=6
+            for i in $(seq 1 $MAX_RETRIES); do
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/v1/health 2>/dev/null || echo "000")
+              if [ "$HTTP_STATUS" = "200" ]; then
+                echo "Health check passed (attempt $i/$MAX_RETRIES)"
+                exit 0
+              fi
+              echo "Health check attempt $i/$MAX_RETRIES: HTTP $HTTP_STATUS (waiting ${RETRY_INTERVAL}s...)"
+              sleep $RETRY_INTERVAL
+            done
+            echo "Health check failed after $MAX_RETRIES attempts"
+            exit 1
+
+      - name: Rollback on failure
+        if: failure()
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.STAGING_SSH_HOST }}
+          username: ${{ secrets.STAGING_SSH_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          port: ${{ secrets.STAGING_SSH_PORT || 22 }}
+          script: |
+            cd ~/screener
+            if [ -x scripts/deploy.sh ]; then
+              ./scripts/deploy.sh --environment staging --rollback
+            else
+              echo "Deploy script not found, manual rollback required"
+            fi
+
+      - name: Deployment summary
+        if: always()
+        run: |
+          echo "## Staging Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Environment | staging |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image Tag | \`${{ steps.tag.outputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Triggered by | ${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Status | ${{ job.status }} |" >> "$GITHUB_STEP_SUMMARY"
+
+  # ==========================================================================
+  # PRODUCTION DEPLOYMENT (manual trigger only)
+  # ==========================================================================
   deploy-production:
     name: Deploy to Production
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'production'
     environment:
       name: production
-      url: https://screener.example.com
-    needs: []
+      url: ${{ vars.PRODUCTION_URL || 'https://screener.example.com' }}
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [ -n "${{ github.event.inputs.image_tag }}" ]; then
+            echo "tag=${{ github.event.inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Copy deployment files to production server
+        uses: appleboy/scp-action@v0.1.7
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          username: ${{ secrets.PRODUCTION_SSH_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT || 22 }}
+          source: "docker-compose.prod.yml,scripts/deploy.sh,infrastructure/nginx/"
+          target: "~/screener"
+          overwrite: true
 
-      - name: Pull latest Docker images
-        run: |
-          docker pull ghcr.io/${{ github.repository }}/backend:latest
-          docker pull ghcr.io/${{ github.repository }}/frontend:latest
+      - name: Deploy to production via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.tag }}
+          REGISTRY: ${{ env.REGISTRY }}
+          BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
+          FRONTEND_IMAGE: ${{ env.FRONTEND_IMAGE }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+        with:
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          username: ${{ secrets.PRODUCTION_SSH_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT || 22 }}
+          envs: IMAGE_TAG,REGISTRY,BACKEND_IMAGE,FRONTEND_IMAGE,GITHUB_TOKEN,GITHUB_ACTOR
+          script_stop: true
+          script: |
+            cd ~/screener
+            chmod +x scripts/deploy.sh
+            ./scripts/deploy.sh \
+              --environment production \
+              --image-tag "$IMAGE_TAG" \
+              --registry "$REGISTRY" \
+              --backend-image "$BACKEND_IMAGE" \
+              --frontend-image "$FRONTEND_IMAGE" \
+              --github-token "$GITHUB_TOKEN" \
+              --github-actor "$GITHUB_ACTOR"
 
-      - name: Verify images
-        run: |
-          echo "✓ Backend image pulled successfully"
-          docker inspect ghcr.io/${{ github.repository }}/backend:latest --format='Image ID: {{.Id}}, Created: {{.Created}}'
-          echo ""
-          echo "✓ Frontend image pulled successfully"
-          docker inspect ghcr.io/${{ github.repository }}/frontend:latest --format='Image ID: {{.Id}}, Created: {{.Created}}'
+      - name: Verify deployment health
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          username: ${{ secrets.PRODUCTION_SSH_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT || 22 }}
+          script_stop: true
+          script: |
+            echo "Running post-deployment health checks..."
+            MAX_RETRIES=15
+            RETRY_INTERVAL=10
+            for i in $(seq 1 $MAX_RETRIES); do
+              HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/v1/health 2>/dev/null || echo "000")
+              if [ "$HTTP_STATUS" = "200" ]; then
+                echo "Health check passed (attempt $i/$MAX_RETRIES)"
 
-      - name: Deploy to production
-        run: |
-          echo "✓ Images verified and ready for production deployment"
-          echo "Note: Actual deployment commands are disabled (placeholder)"
-          # Add Kubernetes deployment commands when ready:
-          # kubectl set image deployment/backend backend=ghcr.io/${{ github.repository }}/backend:${{ github.sha }}
-          # kubectl set image deployment/frontend frontend=ghcr.io/${{ github.repository }}/frontend:${{ github.sha }}
+                # Additional production checks
+                echo "Checking database connectivity..."
+                DB_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health/db 2>/dev/null || echo "000")
+                if [ "$DB_STATUS" != "200" ]; then
+                  echo "WARNING: Database health check returned HTTP $DB_STATUS"
+                fi
 
-      - name: Run health checks
-        run: |
-          echo "Running health checks..."
-          sleep 15
-          # Add health check commands
-          # kubectl wait --for=condition=ready pod -l app=backend --timeout=300s
-          # kubectl wait --for=condition=ready pod -l app=frontend --timeout=300s
+                echo "Checking Redis connectivity..."
+                REDIS_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8000/health/redis 2>/dev/null || echo "000")
+                if [ "$REDIS_STATUS" != "200" ]; then
+                  echo "WARNING: Redis health check returned HTTP $REDIS_STATUS"
+                fi
+
+                exit 0
+              fi
+              echo "Health check attempt $i/$MAX_RETRIES: HTTP $HTTP_STATUS (waiting ${RETRY_INTERVAL}s...)"
+              sleep $RETRY_INTERVAL
+            done
+            echo "Health check failed after $MAX_RETRIES attempts"
+            exit 1
 
       - name: Rollback on failure
         if: failure()
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.PRODUCTION_SSH_HOST }}
+          username: ${{ secrets.PRODUCTION_SSH_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          port: ${{ secrets.PRODUCTION_SSH_PORT || 22 }}
+          script: |
+            cd ~/screener
+            if [ -x scripts/deploy.sh ]; then
+              ./scripts/deploy.sh --environment production --rollback
+            else
+              echo "Deploy script not found, manual rollback required"
+            fi
+
+      - name: Deployment summary
+        if: always()
         run: |
-          echo "Deployment failed, rolling back..."
-          # Add rollback commands
-          # kubectl rollout undo deployment/backend
-          # kubectl rollout undo deployment/frontend
-
-      - name: Notify on Slack
-        if: false  # Disabled: SLACK_WEBHOOK_URL not configured
-        uses: slackapi/slack-github-action@v1
-        with:
-          payload: |
-            {
-              "text": "Production Deployment ${{ job.status }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Production Deployment ${{ job.status }}*\n\nCommit: ${{ github.sha }}\nAuthor: ${{ github.actor }}"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-      - name: Send email notification
-        if: false  # Disabled: Email credentials not configured
-        uses: dawidd6/action-send-mail@v3
-        with:
-          server_address: smtp.gmail.com
-          server_port: 465
-          username: ${{ secrets.EMAIL_USERNAME }}
-          password: ${{ secrets.EMAIL_PASSWORD }}
-          subject: Production Deployment ${{ job.status }}
-          body: |
-            Production deployment has completed with status: ${{ job.status }}
-
-            Commit: ${{ github.sha }}
-            Author: ${{ github.actor }}
-            Workflow: ${{ github.workflow }}
-          to: engineering@example.com
-          from: noreply@screener.example.com
+          echo "## Production Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Environment | production |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Image Tag | \`${{ steps.tag.outputs.tag }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Commit | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Triggered by | ${{ github.actor }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Status | ${{ job.status }} |" >> "$GITHUB_STEP_SUMMARY"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,195 @@
+# ============================================================================
+# Stock Screening Platform - Production Deployment
+# ============================================================================
+# Uses pre-built images from GHCR. Do NOT use for local development.
+# Required: .env file with all secrets on the production server.
+#
+# Deploy:
+#   BACKEND_IMAGE=ghcr.io/org/repo/backend:sha \
+#   FRONTEND_IMAGE=ghcr.io/org/repo/frontend:sha \
+#   docker compose -f docker-compose.prod.yml up -d
+# ============================================================================
+
+services:
+  # ==========================================================================
+  # DATABASE
+  # ==========================================================================
+  postgres:
+    image: timescale/timescaledb:latest-pg16
+    container_name: screener_postgres
+    restart: always
+    environment:
+      POSTGRES_DB: ${DB_NAME:-screener_db}
+      POSTGRES_USER: ${DB_USER:-screener_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-screener_user} -d ${DB_NAME:-screener_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # CACHE
+  # ==========================================================================
+  redis:
+    image: redis:7-alpine
+    container_name: screener_redis
+    restart: always
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required} --maxmemory 512mb --maxmemory-policy allkeys-lru
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "sh", "-c", "redis-cli -a $$REDIS_PASSWORD ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+        reservations:
+          memory: 256M
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # BACKEND API (pre-built image from GHCR)
+  # ==========================================================================
+  backend:
+    image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required}
+    container_name: screener_backend
+    restart: always
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${DB_USER:-screener_user}:${DB_PASSWORD:?DB_PASSWORD is required}@postgres:5432/${DB_NAME:-screener_db}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379/0
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+      ACCESS_TOKEN_EXPIRE_MINUTES: 15
+      REFRESH_TOKEN_EXPIRE_DAYS: 30
+      DEBUG: "false"
+      ENVIRONMENT: production
+      CORS_ORIGINS: ${CORS_ORIGINS:?CORS_ORIGINS is required for production}
+      LOG_LEVEL: WARNING
+      RATE_LIMIT_FREE: ${RATE_LIMIT_FREE:-100}
+      RATE_LIMIT_BASIC: ${RATE_LIMIT_BASIC:-1000}
+      RATE_LIMIT_PRO: ${RATE_LIMIT_PRO:-10000}
+      RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-3600}
+      KRX_API_KEY: ${KRX_API_KEY:-}
+      FGUIDE_API_KEY: ${FGUIDE_API_KEY:-}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: production
+    ports:
+      - "127.0.0.1:8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+        reservations:
+          memory: 256M
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # FRONTEND (pre-built image from GHCR)
+  # ==========================================================================
+  frontend:
+    image: ${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}
+    container_name: screener_frontend
+    restart: always
+    ports:
+      - "127.0.0.1:3000:80"
+    depends_on:
+      - backend
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # NGINX (Reverse Proxy + TLS termination)
+  # ==========================================================================
+  nginx:
+    image: nginx:alpine
+    container_name: screener_nginx
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - frontend
+      - backend
+    volumes:
+      - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./infrastructure/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./infrastructure/nginx/ssl:/etc/nginx/ssl:ro
+      - certbot_webroot:/var/www/certbot:ro
+      - certbot_certs:/etc/nginx/ssl/letsencrypt:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+        reservations:
+          memory: 64M
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # CERTBOT (Let's Encrypt SSL Certificate Management)
+  # ==========================================================================
+  certbot:
+    image: certbot/certbot:latest
+    container_name: screener_certbot
+    restart: unless-stopped
+    volumes:
+      - certbot_webroot:/var/www/certbot
+      - certbot_certs:/etc/letsencrypt
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    networks:
+      - screener_network
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  certbot_webroot:
+    driver: local
+  certbot_certs:
+    driver: local
+
+networks:
+  screener_network:
+    driver: bridge

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,149 @@
+# ============================================================================
+# Stock Screening Platform - Staging Deployment
+# ============================================================================
+# Uses pre-built images from GHCR. Do NOT use for local development.
+# Required: .env file with all secrets on the staging server.
+#
+# Deploy:
+#   BACKEND_IMAGE=ghcr.io/org/repo/backend:sha \
+#   FRONTEND_IMAGE=ghcr.io/org/repo/frontend:sha \
+#   docker compose -f docker-compose.staging.yml up -d
+# ============================================================================
+
+services:
+  # ==========================================================================
+  # DATABASE
+  # ==========================================================================
+  postgres:
+    image: timescale/timescaledb:latest-pg16
+    container_name: screener_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-screener_db}
+      POSTGRES_USER: ${DB_USER:-screener_user}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?DB_PASSWORD is required}
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-screener_user} -d ${DB_NAME:-screener_db}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # CACHE
+  # ==========================================================================
+  redis:
+    image: redis:7-alpine
+    container_name: screener_redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "sh", "-c", "redis-cli -a $$REDIS_PASSWORD ping | grep PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # BACKEND API (pre-built image from GHCR)
+  # ==========================================================================
+  backend:
+    image: ${BACKEND_IMAGE:?BACKEND_IMAGE is required}
+    container_name: screener_backend
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql+asyncpg://${DB_USER:-screener_user}:${DB_PASSWORD:?DB_PASSWORD is required}@postgres:5432/${DB_NAME:-screener_db}
+      REDIS_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD is required}@redis:6379/0
+      SECRET_KEY: ${SECRET_KEY:?SECRET_KEY is required}
+      ACCESS_TOKEN_EXPIRE_MINUTES: 15
+      REFRESH_TOKEN_EXPIRE_DAYS: 30
+      DEBUG: "false"
+      ENVIRONMENT: staging
+      CORS_ORIGINS: ${CORS_ORIGINS:-https://staging.screener.example.com}
+      LOG_LEVEL: INFO
+      RATE_LIMIT_FREE: ${RATE_LIMIT_FREE:-100}
+      RATE_LIMIT_BASIC: ${RATE_LIMIT_BASIC:-500}
+      RATE_LIMIT_PRO: ${RATE_LIMIT_PRO:-2000}
+      RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-60}
+      KRX_API_KEY: ${KRX_API_KEY:-}
+      FGUIDE_API_KEY: ${FGUIDE_API_KEY:-}
+    ports:
+      - "127.0.0.1:8000:8000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 2
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/v1/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # FRONTEND (pre-built image from GHCR)
+  # ==========================================================================
+  frontend:
+    image: ${FRONTEND_IMAGE:?FRONTEND_IMAGE is required}
+    container_name: screener_frontend
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:3000:80"
+    depends_on:
+      - backend
+    networks:
+      - screener_network
+
+  # ==========================================================================
+  # NGINX (Reverse Proxy + TLS termination)
+  # ==========================================================================
+  nginx:
+    image: nginx:alpine
+    container_name: screener_nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - frontend
+      - backend
+    volumes:
+      - ./infrastructure/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./infrastructure/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./infrastructure/nginx/ssl:/etc/nginx/ssl:ro
+      - certbot_webroot:/var/www/certbot:ro
+      - certbot_certs:/etc/nginx/ssl/letsencrypt:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    networks:
+      - screener_network
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  certbot_webroot:
+    driver: local
+  certbot_certs:
+    driver: local
+
+networks:
+  screener_network:
+    driver: bridge

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Deployment Script for Stock Screening Platform
+# ============================================================================
+# Runs on the target server via SSH from the CD pipeline.
+# Handles image pulling, container deployment, and rollback.
+#
+# Usage:
+#   ./scripts/deploy.sh --environment staging --image-tag <sha> [options]
+#   ./scripts/deploy.sh --environment staging --rollback
+#
+# Required options:
+#   --environment       staging or production
+#   --image-tag         Docker image tag (commit SHA)
+#   --registry          Container registry (ghcr.io)
+#   --backend-image     Full backend image name
+#   --frontend-image    Full frontend image name
+#   --github-token      GitHub token for GHCR auth
+#   --github-actor      GitHub username for GHCR auth
+#
+# Rollback:
+#   --rollback          Roll back to the previous deployment
+# ============================================================================
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+DEPLOY_DIR="$HOME/screener"
+BACKUP_DIR="$DEPLOY_DIR/.deploy-backups"
+STATE_FILE="$DEPLOY_DIR/.deploy-state"
+LOG_FILE="$DEPLOY_DIR/.deploy.log"
+MAX_BACKUPS=5
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================================================
+# Argument Parsing
+# ============================================================================
+
+ENVIRONMENT=""
+IMAGE_TAG=""
+REGISTRY=""
+BACKEND_IMAGE=""
+FRONTEND_IMAGE=""
+GITHUB_TOKEN=""
+GITHUB_ACTOR=""
+ROLLBACK=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --environment)    ENVIRONMENT="$2"; shift 2 ;;
+        --image-tag)      IMAGE_TAG="$2"; shift 2 ;;
+        --registry)       REGISTRY="$2"; shift 2 ;;
+        --backend-image)  BACKEND_IMAGE="$2"; shift 2 ;;
+        --frontend-image) FRONTEND_IMAGE="$2"; shift 2 ;;
+        --github-token)   GITHUB_TOKEN="$2"; shift 2 ;;
+        --github-actor)   GITHUB_ACTOR="$2"; shift 2 ;;
+        --rollback)       ROLLBACK=true; shift ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+log() {
+    local timestamp
+    timestamp=$(date '+%Y-%m-%d %H:%M:%S')
+    echo -e "[$timestamp] $1" | tee -a "$LOG_FILE"
+}
+
+die() {
+    log "${RED}ERROR: $1${NC}"
+    exit 1
+}
+
+get_compose_file() {
+    case "$ENVIRONMENT" in
+        staging)    echo "$DEPLOY_DIR/docker-compose.staging.yml" ;;
+        production) echo "$DEPLOY_DIR/docker-compose.prod.yml" ;;
+        *) die "Unknown environment: $ENVIRONMENT" ;;
+    esac
+}
+
+# ============================================================================
+# Validation
+# ============================================================================
+
+validate_args() {
+    [ -z "$ENVIRONMENT" ] && die "--environment is required"
+
+    if [ "$ROLLBACK" = true ]; then
+        return 0
+    fi
+
+    [ -z "$IMAGE_TAG" ] && die "--image-tag is required"
+    [ -z "$REGISTRY" ] && die "--registry is required"
+    [ -z "$BACKEND_IMAGE" ] && die "--backend-image is required"
+    [ -z "$FRONTEND_IMAGE" ] && die "--frontend-image is required"
+    [ -z "$GITHUB_TOKEN" ] && die "--github-token is required"
+    [ -z "$GITHUB_ACTOR" ] && die "--github-actor is required"
+
+    local compose_file
+    compose_file=$(get_compose_file)
+    [ ! -f "$compose_file" ] && die "Compose file not found: $compose_file"
+}
+
+# ============================================================================
+# Backup Current State
+# ============================================================================
+
+backup_current_state() {
+    mkdir -p "$BACKUP_DIR"
+
+    local compose_file
+    compose_file=$(get_compose_file)
+
+    # Save currently running image tags
+    local backup_file="$BACKUP_DIR/$(date '+%Y%m%d_%H%M%S')_${ENVIRONMENT}.env"
+
+    log "Backing up current deployment state..."
+
+    # Get current image IDs from running containers
+    local current_backend_image=""
+    local current_frontend_image=""
+
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "screener_backend"; then
+        current_backend_image=$(docker inspect screener_backend --format='{{.Config.Image}}' 2>/dev/null || echo "")
+    fi
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "screener_frontend"; then
+        current_frontend_image=$(docker inspect screener_frontend --format='{{.Config.Image}}' 2>/dev/null || echo "")
+    fi
+
+    cat > "$backup_file" <<EOF
+ENVIRONMENT=$ENVIRONMENT
+TIMESTAMP=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+BACKEND_IMAGE=$current_backend_image
+FRONTEND_IMAGE=$current_frontend_image
+COMPOSE_FILE=$compose_file
+EOF
+
+    # Update state file with latest backup reference
+    echo "$backup_file" > "$STATE_FILE"
+
+    log "${GREEN}Backup saved: $backup_file${NC}"
+
+    # Cleanup old backups (keep MAX_BACKUPS most recent)
+    local backup_count
+    backup_count=$(ls -1 "$BACKUP_DIR"/*_${ENVIRONMENT}.env 2>/dev/null | wc -l)
+    if [ "$backup_count" -gt "$MAX_BACKUPS" ]; then
+        ls -1t "$BACKUP_DIR"/*_${ENVIRONMENT}.env | tail -n +"$((MAX_BACKUPS + 1))" | xargs rm -f
+        log "Cleaned up old backups (kept $MAX_BACKUPS most recent)"
+    fi
+}
+
+# ============================================================================
+# Rollback
+# ============================================================================
+
+do_rollback() {
+    log "${YELLOW}Starting rollback for $ENVIRONMENT...${NC}"
+
+    if [ ! -f "$STATE_FILE" ]; then
+        die "No deployment state found. Cannot rollback."
+    fi
+
+    local backup_file
+    backup_file=$(cat "$STATE_FILE")
+
+    if [ ! -f "$backup_file" ]; then
+        die "Backup file not found: $backup_file"
+    fi
+
+    # shellcheck source=/dev/null
+    source "$backup_file"
+
+    local compose_file
+    compose_file=$(get_compose_file)
+
+    if [ -z "$BACKEND_IMAGE" ] || [ -z "$FRONTEND_IMAGE" ]; then
+        die "No previous image references found in backup"
+    fi
+
+    log "Rolling back to:"
+    log "  Backend:  $BACKEND_IMAGE"
+    log "  Frontend: $FRONTEND_IMAGE"
+
+    # Set images for docker compose
+    export BACKEND_IMAGE
+    export FRONTEND_IMAGE
+
+    docker compose -f "$compose_file" up -d --no-build --remove-orphans 2>&1 | tee -a "$LOG_FILE"
+
+    log "${GREEN}Rollback completed${NC}"
+}
+
+# ============================================================================
+# Deploy
+# ============================================================================
+
+do_deploy() {
+    local compose_file
+    compose_file=$(get_compose_file)
+
+    log "============================================"
+    log "Deploying to $ENVIRONMENT"
+    log "  Image tag: $IMAGE_TAG"
+    log "  Compose:   $compose_file"
+    log "============================================"
+
+    # Step 1: Authenticate with GHCR
+    log "Authenticating with container registry..."
+    echo "$GITHUB_TOKEN" | docker login "$REGISTRY" -u "$GITHUB_ACTOR" --password-stdin 2>&1 | tee -a "$LOG_FILE"
+
+    # Step 2: Pull new images
+    log "Pulling images with tag: $IMAGE_TAG..."
+    docker pull "${BACKEND_IMAGE}:${IMAGE_TAG}" 2>&1 | tee -a "$LOG_FILE"
+    docker pull "${FRONTEND_IMAGE}:${IMAGE_TAG}" 2>&1 | tee -a "$LOG_FILE"
+
+    # Also tag as environment-specific for compose reference
+    docker tag "${BACKEND_IMAGE}:${IMAGE_TAG}" "${BACKEND_IMAGE}:${ENVIRONMENT}"
+    docker tag "${FRONTEND_IMAGE}:${IMAGE_TAG}" "${FRONTEND_IMAGE}:${ENVIRONMENT}"
+
+    log "${GREEN}Images pulled successfully${NC}"
+
+    # Step 3: Backup current state
+    backup_current_state
+
+    # Step 4: Deploy with Docker Compose
+    log "Starting deployment..."
+    export BACKEND_IMAGE="${BACKEND_IMAGE}:${IMAGE_TAG}"
+    export FRONTEND_IMAGE="${FRONTEND_IMAGE}:${IMAGE_TAG}"
+
+    docker compose -f "$compose_file" up -d --no-build --remove-orphans 2>&1 | tee -a "$LOG_FILE"
+
+    # Step 5: Wait for containers to be running
+    log "Waiting for containers to start..."
+    sleep 5
+
+    # Check container status
+    local failed=false
+    for service in backend postgres redis; do
+        local container_name="screener_${service}"
+        if docker ps --format '{{.Names}}' | grep -q "$container_name"; then
+            local status
+            status=$(docker inspect "$container_name" --format='{{.State.Status}}' 2>/dev/null || echo "unknown")
+            log "  $container_name: $status"
+            if [ "$status" != "running" ]; then
+                failed=true
+            fi
+        else
+            log "${YELLOW}  $container_name: not found (may be expected)${NC}"
+        fi
+    done
+
+    if [ "$failed" = true ]; then
+        die "Some containers failed to start"
+    fi
+
+    log "${GREEN}Deployment to $ENVIRONMENT completed successfully${NC}"
+    log "============================================"
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+mkdir -p "$DEPLOY_DIR"
+touch "$LOG_FILE"
+
+validate_args
+
+if [ "$ROLLBACK" = true ]; then
+    do_rollback
+else
+    do_deploy
+fi


### PR DESCRIPTION
Closes #470

## Summary

- Replace all placeholder `echo` statements in `cd.yml` with actual SSH-based deployment
- Add `docker-compose.staging.yml` for staging deployments using pre-built GHCR images
- Add `docker-compose.prod.yml` for production with resource limits and Certbot
- Add `scripts/deploy.sh` for server-side deployment and rollback operations
- Split remaining work into sub-issues: #492 (notifications), #493 (zero-downtime)

## Architecture

```
CI (main push) → Build Docker images → Push to GHCR
                                            ↓
CD (auto/manual) → SSH into server → Pull images → Docker Compose up → Health check
                                                                            ↓
                                                                     Pass: Done
                                                                     Fail: Rollback
```

### Staging vs Production

| Aspect | Staging | Production |
|--------|---------|------------|
| Trigger | Auto (main push) | Manual (workflow_dispatch) |
| Workers | 2 | 4 |
| Health retries | 10 × 6s = 60s | 15 × 10s = 150s |
| Resource limits | None | Memory limits per service |
| Log level | INFO | WARNING |
| Certbot | No | Yes |

### Required GitHub Secrets

| Secret | Description |
|--------|-------------|
| `STAGING_SSH_HOST` | Staging server hostname |
| `STAGING_SSH_USER` | SSH username for staging |
| `STAGING_SSH_KEY` | SSH private key for staging |
| `PRODUCTION_SSH_HOST` | Production server hostname |
| `PRODUCTION_SSH_USER` | SSH username for production |
| `PRODUCTION_SSH_KEY` | SSH private key for production |

### Deploy Script Features

- GHCR authentication and image pulling
- Backup of current deployment state before deploy
- Automatic cleanup of old backups (keeps last 5)
- Rollback support via `--rollback` flag
- Colored logging with timestamps

## Test Plan

- [x] YAML syntax validation for all compose files (`yaml.safe_load`) — staging(5 services), prod(6 services) parsed OK
- [x] Bash syntax validation for deploy.sh (`bash -n`) — no syntax errors
- [x] cd.yml workflow structure validation — 13/13 checks passed (triggers, jobs, SSH, health, rollback, concurrency, step summary)
- [x] Staging deployment logic — auto-triggers on main push, SSH secrets referenced, deploy.sh called with `--environment staging`
- [x] Production deployment logic — manual workflow_dispatch only, environment approval gate, deploy.sh called with `--environment production`
- [x] Rollback mechanism — backup_current_state() saves running image IDs, `--rollback` restores from backup, cd.yml triggers rollback on `failure()` for both environments, old backups cleaned (keeps 5)
- [x] Health check retry behavior — staging 10×6s=60s / production 15×10s=150s, curl HTTP 200 validation, graceful fallback on curl failure, production adds DB+Redis checks, deploy.sh verifies container running state