### PR TITLE
fix(infra): Align Airflow version to 3.1.2 across Docker and requirements

### DIFF
--- a/data_pipeline/config/setup_connections.py
+++ b/data_pipeline/config/setup_connections.py
@@ -38,7 +38,7 @@ def setup_screener_db_connection() -> bool:
     """
     try:
         from airflow.models import Connection
-        from airflow.utils.db import create_session
+        from airflow.utils.session import create_session
 
         # Get environment variables
         host = os.getenv('SCREENER_DB_HOST', 'postgres')

--- a/data_pipeline/dags/daily_price_ingestion_dag.py
+++ b/data_pipeline/dags/daily_price_ingestion_dag.py
@@ -58,7 +58,7 @@ dag = DAG(
     'daily_price_ingestion',
     default_args=default_args,
     description='Ingest daily stock prices from KRX',
-    schedule_interval='0 18 * * 1-5',  # Mon-Fri at 18:00 KST
+    schedule='0 18 * * 1-5',  # Mon-Fri at 18:00 KST
     start_date=datetime(2024, 1, 1),
     catchup=False,
     max_active_runs=1,
@@ -561,7 +561,7 @@ def log_ingestion_status(**context):
         loaded_count,
         fetched_count - valid_count,
         status,
-        context['execution_date']
+        context['logical_date']
     ))
 
     logger.info(f"Logged ingestion status: {status}")
@@ -575,7 +575,6 @@ def log_ingestion_status(**context):
 fetch_prices = PythonOperator(
     task_id='fetch_krx_prices',
     python_callable=fetch_krx_prices,
-    provide_context=True,
     dag=dag,
 )
 
@@ -583,7 +582,6 @@ fetch_prices = PythonOperator(
 validate_data = PythonOperator(
     task_id='validate_price_data',
     python_callable=validate_price_data,
-    provide_context=True,
     dag=dag,
 )
 
@@ -591,7 +589,6 @@ validate_data = PythonOperator(
 load_to_db = PythonOperator(
     task_id='load_prices_to_db',
     python_callable=load_prices_to_db,
-    provide_context=True,
     dag=dag,
 )
 
@@ -599,7 +596,6 @@ load_to_db = PythonOperator(
 check_completeness = PythonOperator(
     task_id='check_data_completeness',
     python_callable=check_data_completeness,
-    provide_context=True,
     dag=dag,
 )
 
@@ -618,7 +614,6 @@ refresh_aggregates = PostgresOperator(
 log_status = PythonOperator(
     task_id='log_ingestion_status',
     python_callable=log_ingestion_status,
-    provide_context=True,
     trigger_rule='all_done',  # Run even if previous tasks failed
     dag=dag,
 )

--- a/data_pipeline/dags/indicator_calculation_dag.py
+++ b/data_pipeline/dags/indicator_calculation_dag.py
@@ -41,7 +41,7 @@ dag = DAG(
     'indicator_calculation',
     default_args=default_args,
     description='Calculate 200+ indicators for all stocks',
-    schedule_interval=None,  # Triggered by daily_price_ingestion
+    schedule=None,  # Triggered by daily_price_ingestion
     start_date=datetime(2024, 1, 1),
     catchup=False,
     max_active_runs=1,
@@ -1096,7 +1096,6 @@ def calculate_indicators_for_all_stocks(**context):
 calculate_indicators = PythonOperator(
     task_id='calculate_indicators',
     python_callable=calculate_indicators_for_all_stocks,
-    provide_context=True,
     execution_timeout=timedelta(minutes=30),
     dag=dag,
 )
@@ -1118,7 +1117,7 @@ log_calculation_status = PostgresOperator(
         ) VALUES (
             'internal', 'indicators', {{ ti.xcom_pull(task_ids='calculate_indicators', key='calculated_count') }},
             {{ ti.xcom_pull(task_ids='calculate_indicators', key='failed_count') }},
-            'success', '{{ execution_date }}', NOW()
+            'success', '{{ logical_date }}', NOW()
         )
     """,
     dag=dag,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,7 +147,7 @@ services:
 
   airflow_webserver:
     profiles: ["full"]  # Optional service, start with --profile full
-    image: apache/airflow:2.8.0-python3.11
+    image: apache/airflow:3.1.2-python3.12
     container_name: screener_airflow_webserver
     restart: unless-stopped
     environment:
@@ -157,7 +157,7 @@ services:
       AIRFLOW__WEBSERVER__SECRET_KEY: ${AIRFLOW_SECRET_KEY:?AIRFLOW_SECRET_KEY environment variable is required}
       AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
       AIRFLOW__WEBSERVER__EXPOSE_CONFIG: 'true'
-      _AIRFLOW_DB_UPGRADE: 'true'
+      _AIRFLOW_DB_MIGRATE: 'true'
       _AIRFLOW_WWW_USER_CREATE: 'true'
       _AIRFLOW_WWW_USER_USERNAME: ${AIRFLOW_USER:-admin}
       _AIRFLOW_WWW_USER_PASSWORD: ${AIRFLOW_PASSWORD:?AIRFLOW_PASSWORD environment variable is required}
@@ -189,7 +189,7 @@ services:
 
   airflow_scheduler:
     profiles: ["full"]  # Optional service, start with --profile full
-    image: apache/airflow:2.8.0-python3.11
+    image: apache/airflow:3.1.2-python3.12
     container_name: screener_airflow_scheduler
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Closes #471

## Summary

- Resolve Airflow version mismatch: Docker image was 2.8.0, requirements.txt specified 3.1.2
- Upgrade Docker images to `apache/airflow:3.1.2-python3.12` (python3.11 not available for 3.x)
- Update DAG files and setup scripts for Airflow 3.x compatibility

## Changes

| File | Change | Reason |
|------|--------|--------|
| `docker-compose.yml` | Image `2.8.0-python3.11` → `3.1.2-python3.12` | Version alignment |
| `docker-compose.yml` | `_AIRFLOW_DB_UPGRADE` → `_AIRFLOW_DB_MIGRATE` | Renamed in Airflow 2.7+ |
| `daily_price_ingestion_dag.py` | `schedule_interval=` → `schedule=` | Deprecated in 3.x |
| `daily_price_ingestion_dag.py` | Remove `provide_context=True` (6 places) | No-op since 2.x |
| `daily_price_ingestion_dag.py` | `context['execution_date']` → `context['logical_date']` | Removed in 3.x |
| `indicator_calculation_dag.py` | `schedule_interval=` → `schedule=` | Deprecated in 3.x |
| `indicator_calculation_dag.py` | Remove `provide_context=True` | No-op since 2.x |
| `indicator_calculation_dag.py` | `{{ execution_date }}` → `{{ logical_date }}` | Removed in 3.x |
| `setup_connections.py` | `airflow.utils.db` → `airflow.utils.session` | Import path changed in 3.x |

## Version Decision

**Chose Airflow 3.x** because:
1. `requirements.txt` already targets 3.1.2 with security rationale (werkzeug & flask-appbuilder CVEs)
2. DAGs use classic API (`DAG()`, `PythonOperator`) which is still supported in 3.x
3. Forward-looking: 2.x is approaching end of life

**Python 3.12** (not 3.11) because Airflow 3.1.2 Docker images only provide python3.10, 3.12, 3.13.

## Test Plan

- [x] Docker image tag `apache/airflow:3.1.2-python3.12` verified on Docker Hub
- [x] `docker-compose.yml` YAML syntax validation
- [x] No `schedule_interval` remaining in DAG files
- [x] No `provide_context=True` remaining in DAG files
- [x] No `execution_date` context variable usage remaining
- [x] `setup_connections.py` uses `airflow.utils.session` import
- [x] `requirements.txt` version (3.1.2) matches Docker image (3.1.2)
- [ ] Airflow container startup with new image (requires Docker)

## References

- [Upgrading to Airflow 3](https://airflow.apache.org/docs/apache-airflow/stable/installation/upgrading_to_airflow3.html)
- [Docker Entrypoint docs](https://airflow.apache.org/docs/docker-stack/entrypoint.html)
- [Astronomer migration guide](https://www.astronomer.io/docs/learn/airflow-upgrade-2-3/)