### PR TITLE
feat(infra): Add Prometheus exporter containers for monitoring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -326,6 +326,49 @@ services:
     networks:
       - screener_network
 
+  # --------------------------------------------------------------------------
+  # EXPORTERS (Prometheus metric collectors)
+  # --------------------------------------------------------------------------
+
+  postgres-exporter:
+    profiles: ["monitoring", "full"]
+    image: prometheuscommunity/postgres-exporter:latest
+    container_name: screener_postgres_exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: postgresql://${DB_USER:-screener_user}:${DB_PASSWORD:?DB_PASSWORD environment variable is required}@postgres:5432/${DB_NAME:-screener_db}?sslmode=disable
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - screener_network
+
+  redis-exporter:
+    profiles: ["monitoring", "full"]
+    image: oliver006/redis_exporter:latest
+    container_name: screener_redis_exporter
+    restart: unless-stopped
+    environment:
+      REDIS_ADDR: redis://redis:6379
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?REDIS_PASSWORD environment variable is required}
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - screener_network
+
+  nginx-exporter:
+    profiles: ["monitoring", "full"]
+    image: nginx/nginx-prometheus-exporter:latest
+    container_name: screener_nginx_exporter
+    restart: unless-stopped
+    command:
+      - '--nginx.scrape-uri=http://nginx:8081/stub_status'
+    depends_on:
+      - nginx
+    networks:
+      - screener_network
+
 # ============================================================================
 # VOLUMES
 # ============================================================================

--- a/infrastructure/monitoring/prometheus/prometheus.yml
+++ b/infrastructure/monitoring/prometheus/prometheus.yml
@@ -88,27 +88,31 @@ scrape_configs:
   # ============================================================================
   # CELERY WORKERS
   # ============================================================================
+  # Celery does not natively expose Prometheus metrics.
+  # Uncomment and configure when a celery-exporter or Flower with metrics is deployed.
 
-  - job_name: 'celery'
-    scrape_interval: 30s
-    metrics_path: '/metrics'
-    static_configs:
-      - targets: ['celery_worker:8001']
-        labels:
-          service: 'celery-worker'
-          tier: 'background-jobs'
+  # - job_name: 'celery'
+  #   scrape_interval: 30s
+  #   metrics_path: '/metrics'
+  #   static_configs:
+  #     - targets: ['celery-exporter:9808']
+  #       labels:
+  #         service: 'celery-worker'
+  #         tier: 'background-jobs'
 
   # ============================================================================
   # AIRFLOW
   # ============================================================================
+  # Requires Airflow to be configured with statsd-exporter or
+  # the apache-airflow[statsd] extra. Uncomment when metrics are enabled.
 
-  - job_name: 'airflow'
-    scrape_interval: 30s
-    static_configs:
-      - targets: ['airflow-exporter:9112']
-        labels:
-          service: 'airflow'
-          tier: 'data-pipeline'
+  # - job_name: 'airflow'
+  #   scrape_interval: 30s
+  #   static_configs:
+  #     - targets: ['airflow-statsd-exporter:9102']
+  #       labels:
+  #         service: 'airflow'
+  #         tier: 'data-pipeline'
 
   # ============================================================================
   # NODE EXPORTER (System Metrics)

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -43,4 +43,19 @@ http {
 
     # Include server configurations
     include /etc/nginx/conf.d/*.conf;
+
+    # Internal metrics server for Prometheus nginx-exporter
+    server {
+        listen 8081;
+        server_name localhost;
+        access_log off;
+
+        location /stub_status {
+            stub_status;
+        }
+
+        location / {
+            return 404;
+        }
+    }
 }


### PR DESCRIPTION
Closes #512
Part of #478

## Summary
- Add `postgres-exporter`, `redis-exporter`, and `nginx-exporter` containers to `docker-compose.yml` under the monitoring profile
- Add internal `stub_status` server block on port 8081 in `nginx.conf` for nginx-exporter to scrape
- Comment out celery and airflow scrape targets in `prometheus.yml` (these services don't expose Prometheus metrics yet)

## Exporter Configuration

| Exporter | Image | Port | Connects To |
|----------|-------|------|-------------|
| postgres-exporter | `prometheuscommunity/postgres-exporter:latest` | 9187 | `postgres:5432` via `DATA_SOURCE_NAME` |
| redis-exporter | `oliver006/redis_exporter:latest` | 9121 | `redis:6379` via `REDIS_ADDR` + `REDIS_PASSWORD` |
| nginx-exporter | `nginx/nginx-prometheus-exporter:latest` | 9113 | `nginx:8081/stub_status` |

## Design Decisions
- **Internal port 8081 for stub_status**: Dedicated internal server block avoids exposing metrics on the public-facing ports (80/443). Only accessible within the Docker network.
- **Celery/Airflow commented out**: These services don't natively expose Prometheus metrics. Will be addressed when dedicated exporters (celery-exporter, statsd-exporter for Airflow) are configured.
- **All exporters use `profiles: ["monitoring", "full"]`**: Consistent with existing prometheus/grafana containers — only started when monitoring profile is active.

## Test Plan
- [x] `docker compose config --quiet` passes (YAML syntax valid)
- [x] `prometheus.yml` YAML validation passes
- [ ] Manual verification: `docker compose --profile monitoring up` starts all exporters
- [ ] Manual verification: Prometheus targets page shows exporters as UP
- [x] No changes to backend/frontend code — CI Pipeline (linting, tests) should pass unchanged

## Files Changed
| File | Changes |
|------|---------|
| `docker-compose.yml` | Add postgres-exporter, redis-exporter, nginx-exporter services |
| `infrastructure/monitoring/prometheus/prometheus.yml` | Comment out celery/airflow targets (no metrics yet) |
| `infrastructure/nginx/nginx.conf` | Add internal stub_status server on port 8081 |