### PR TITLE
fix(config): resolve rate limit configuration value inconsistencies

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -101,16 +101,17 @@ class Settings(BaseSettings):
         return []  # Default to empty list if neither string nor list
 
     # ========================================================================
-    # RATE LIMITING
+    # RATE LIMITING (single source of truth — do not duplicate in docker-compose)
+    # Override via environment variables or .env file when needed.
     # ========================================================================
 
-    # General API rate limits (requests per hour)
-    RATE_LIMIT_FREE: int = 100  # 100 req/hour
-    RATE_LIMIT_BASIC: int = 1000  # 1000 req/hour
-    RATE_LIMIT_PRO: int = 10000  # 10000 req/hour
+    # General API rate limits (requests per window)
+    RATE_LIMIT_FREE: int = 100  # Free tier: 100 req/window
+    RATE_LIMIT_BASIC: int = 1000  # Basic tier: 1000 req/window
+    RATE_LIMIT_PRO: int = 10000  # Pro tier: 10000 req/window
     RATE_LIMIT_WINDOW: int = 3600  # Rate limit window in seconds (1 hour)
 
-    # Per-endpoint rate limits (requests per hour)
+    # Per-endpoint rate limits (requests per window)
     # These limits are in addition to general tier limits
     RATE_LIMIT_SCREENING: int = 50  # Screening queries (more expensive)
     RATE_LIMIT_STOCK_DETAIL: int = 200  # Stock detail queries

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -82,10 +82,7 @@ services:
       ENVIRONMENT: production
       CORS_ORIGINS: ${CORS_ORIGINS:?CORS_ORIGINS is required for production}
       LOG_LEVEL: WARNING
-      RATE_LIMIT_FREE: ${RATE_LIMIT_FREE:-100}
-      RATE_LIMIT_BASIC: ${RATE_LIMIT_BASIC:-1000}
-      RATE_LIMIT_PRO: ${RATE_LIMIT_PRO:-10000}
-      RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-3600}
+      # Rate Limiting — defaults defined in backend/app/core/config.py (single source of truth)
       KRX_API_KEY: ${KRX_API_KEY:-}
       FGUIDE_API_KEY: ${FGUIDE_API_KEY:-}
       SENTRY_DSN: ${SENTRY_DSN:-}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -70,10 +70,7 @@ services:
       ENVIRONMENT: staging
       CORS_ORIGINS: ${CORS_ORIGINS:-https://staging.screener.example.com}
       LOG_LEVEL: INFO
-      RATE_LIMIT_FREE: ${RATE_LIMIT_FREE:-100}
-      RATE_LIMIT_BASIC: ${RATE_LIMIT_BASIC:-500}
-      RATE_LIMIT_PRO: ${RATE_LIMIT_PRO:-2000}
-      RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-60}
+      # Rate Limiting — defaults defined in backend/app/core/config.py (single source of truth)
       KRX_API_KEY: ${KRX_API_KEY:-}
       FGUIDE_API_KEY: ${FGUIDE_API_KEY:-}
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,15 +85,8 @@ services:
       ENVIRONMENT: ${ENVIRONMENT:-development}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:5173,http://localhost:3000}
 
-      # Rate Limiting
-      RATE_LIMIT_FREE: ${RATE_LIMIT_FREE:-100}
-      RATE_LIMIT_BASIC: ${RATE_LIMIT_BASIC:-500}
-      RATE_LIMIT_PRO: ${RATE_LIMIT_PRO:-2000}
-      RATE_LIMIT_WINDOW: ${RATE_LIMIT_WINDOW:-60}
-      RATE_LIMIT_SCREENING: ${RATE_LIMIT_SCREENING:-50}
-      RATE_LIMIT_STOCK_DETAIL: ${RATE_LIMIT_STOCK_DETAIL:-100}
-      RATE_LIMIT_AUTH: ${RATE_LIMIT_AUTH:-10}
-      RATE_LIMIT_WHITELIST_PATHS: ${RATE_LIMIT_WHITELIST_PATHS:-/health,/docs,/redoc,/openapi.json}
+      # Rate Limiting — defaults defined in backend/app/core/config.py (single source of truth)
+      # Override via .env file or environment variables when needed
 
       # External APIs
       KRX_API_KEY: ${KRX_API_KEY}


### PR DESCRIPTION
## Summary
- Remove duplicate rate limit defaults from all docker-compose files (dev, staging, prod)
- Establish `backend/app/core/config.py` as the single source of truth for rate limit configuration
- Update comments to clarify the configuration hierarchy

## Problem
Rate limit default values differed between `config.py` and `docker-compose.yml`, creating unpredictable behavior:

| Setting | config.py | docker-compose (dev) | staging | prod |
|---------|-----------|---------------------|---------|------|
| RATE_LIMIT_BASIC | 1000 | **500** | **500** | 1000 |
| RATE_LIMIT_PRO | 10000 | **2000** | **2000** | 10000 |
| RATE_LIMIT_WINDOW | 3600 (1hr) | **60** (1min) | **60** (1min) | 3600 |
| RATE_LIMIT_STOCK_DETAIL | 200 | **100** | - | - |
| WHITELIST_PATHS | 6 paths | **4 paths** | - | - |

## Solution
- `config.py` defines all defaults (single source of truth)
- Docker-compose files no longer specify rate limit fallback values
- Override via `.env` file or environment variables when needed

Closes #480

## Test plan
- [ ] Verify backend starts without rate limit env vars (uses config.py defaults)
- [ ] Verify rate limit env vars from `.env` file still override config.py defaults
- [ ] Verify docker-compose files parse without errors