### PR TITLE
feat(infra): add Prometheus alerting rules and Alertmanager configuration (#513)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,6 +287,7 @@ services:
       - "${PROMETHEUS_PORT:-9090}:9090"
     volumes:
       - ./infrastructure/monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./infrastructure/monitoring/prometheus/alerts:/etc/prometheus/alerts:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
@@ -316,6 +317,21 @@ services:
       - ./infrastructure/monitoring/grafana/dashboards/json:/var/lib/grafana/dashboards:ro
       - ./infrastructure/monitoring/grafana/datasources:/etc/grafana/provisioning/datasources:ro
       - grafana_data:/var/lib/grafana
+    networks:
+      - screener_network
+
+  alertmanager:
+    profiles: ["monitoring", "full"]
+    image: prom/alertmanager:latest
+    container_name: screener_alertmanager
+    restart: unless-stopped
+    ports:
+      - "${ALERTMANAGER_PORT:-9093}:9093"
+    volumes:
+      - ./infrastructure/monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--storage.path=/alertmanager'
     networks:
       - screener_network
 

--- a/infrastructure/monitoring/alertmanager/alertmanager.yml
+++ b/infrastructure/monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,89 @@
+# ============================================================================
+# Alertmanager Configuration - Stock Screening Platform
+# ============================================================================
+#
+# Default configuration uses a local webhook receiver.
+# To enable Slack or email, update the receivers section and set
+# the corresponding environment variables or secrets.
+#
+# Environment variables (set in .env or docker-compose):
+#   ALERTMANAGER_SLACK_WEBHOOK_URL - Slack incoming webhook URL
+#   SMTP_SMARTHOST                 - SMTP relay host:port
+#   SMTP_FROM                      - Sender email address
+#   ALERTMANAGER_EMAIL_TO          - Recipient email address
+
+global:
+  resolve_timeout: 5m
+
+# ============================================================================
+# ROUTING TREE
+# ============================================================================
+
+route:
+  # Default receiver for all alerts
+  receiver: 'default-webhook'
+
+  # Group alerts by alertname and service to reduce noise
+  group_by: ['alertname', 'service']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+  routes:
+    # Critical alerts: shorter repeat interval
+    - match:
+        severity: critical
+      receiver: 'default-webhook'
+      repeat_interval: 1h
+
+    # Warning alerts: standard repeat interval
+    - match:
+        severity: warning
+      receiver: 'default-webhook'
+      repeat_interval: 4h
+
+# ============================================================================
+# RECEIVERS
+# ============================================================================
+
+receivers:
+  # Default: log-only webhook (replace with Slack/email when ready)
+  - name: 'default-webhook'
+    webhook_configs:
+      - url: 'http://backend:8000/v1/webhooks/alertmanager'
+        send_resolved: true
+
+  # Uncomment to enable Slack notifications:
+  # - name: 'slack-critical'
+  #   slack_configs:
+  #     - api_url: '${ALERTMANAGER_SLACK_WEBHOOK_URL}'
+  #       channel: '#alerts-critical'
+  #       title: '{{ .GroupLabels.alertname }}'
+  #       text: >-
+  #         {{ range .Alerts }}
+  #         *{{ .Annotations.summary }}*
+  #         {{ .Annotations.description }}
+  #         {{ end }}
+  #       send_resolved: true
+
+  # Uncomment to enable email notifications:
+  # - name: 'email-critical'
+  #   email_configs:
+  #     - to: '${ALERTMANAGER_EMAIL_TO}'
+  #       from: '${SMTP_FROM}'
+  #       smarthost: '${SMTP_SMARTHOST}'
+  #       require_tls: true
+  #       send_resolved: true
+
+# ============================================================================
+# INHIBITION RULES
+# ============================================================================
+# Suppress lower-severity alerts when a higher-severity alert fires
+# for the same service.
+
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'service']

--- a/infrastructure/monitoring/prometheus/alerts/performance.yml
+++ b/infrastructure/monitoring/prometheus/alerts/performance.yml
@@ -1,0 +1,130 @@
+# ============================================================================
+# Performance Alert Rules
+# ============================================================================
+# Alerts for error rates, latency, and slow queries.
+
+groups:
+  - name: performance
+    rules:
+      # ------------------------------------------------------------------
+      # High HTTP Error Rate (5xx)
+      # ------------------------------------------------------------------
+
+      - alert: HighErrorRate
+        expr: >-
+          (
+            sum(rate(http_requests_total{status_code=~"5.."}[5m])) by (service)
+            /
+            sum(rate(http_requests_total[5m])) by (service)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High 5xx error rate on {{ $labels.service }}"
+          description: >-
+            {{ $labels.service }} has a 5xx error rate above 5%
+            (current: {{ $value | humanizePercentage }}) for the last 5 minutes.
+
+      # ------------------------------------------------------------------
+      # High Request Latency (P95)
+      # ------------------------------------------------------------------
+
+      - alert: HighLatencyP95
+        expr: >-
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le, endpoint)
+          ) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High P95 latency on {{ $labels.endpoint }}"
+          description: >-
+            P95 request duration for {{ $labels.endpoint }} exceeds 2 seconds
+            (current: {{ $value | humanizeDuration }}).
+
+      # ------------------------------------------------------------------
+      # High Request Latency (P99)
+      # ------------------------------------------------------------------
+
+      - alert: HighLatencyP99
+        expr: >-
+          histogram_quantile(0.99,
+            sum(rate(http_request_duration_seconds_bucket[5m])) by (le, endpoint)
+          ) > 5
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical P99 latency on {{ $labels.endpoint }}"
+          description: >-
+            P99 request duration for {{ $labels.endpoint }} exceeds 5 seconds
+            (current: {{ $value | humanizeDuration }}).
+
+      # ------------------------------------------------------------------
+      # Slow Database Queries
+      # ------------------------------------------------------------------
+
+      - alert: HighSlowQueryRate
+        expr: rate(db_slow_queries_total[5m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High rate of slow database queries"
+          description: >-
+            More than 0.1 slow queries per second detected over the last
+            5 minutes (current: {{ $value | humanize }} queries/sec).
+
+      # ------------------------------------------------------------------
+      # Database Query Errors
+      # ------------------------------------------------------------------
+
+      - alert: DatabaseQueryErrors
+        expr: rate(db_query_errors_total[5m]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database query errors detected"
+          description: >-
+            Database query errors are occurring at a rate of
+            {{ $value | humanize }} errors/sec over the last 5 minutes.
+
+      # ------------------------------------------------------------------
+      # Low Cache Hit Ratio
+      # ------------------------------------------------------------------
+
+      - alert: LowCacheHitRatio
+        expr: cache_hit_ratio < 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Low cache hit ratio"
+          description: >-
+            Cache hit ratio has been below 50% for the last 10 minutes
+            (current: {{ $value | humanizePercentage }}).
+            This may indicate a cache warming issue or configuration problem.
+
+      # ------------------------------------------------------------------
+      # High Login Failure Rate
+      # ------------------------------------------------------------------
+
+      - alert: HighLoginFailureRate
+        expr: >-
+          (
+            sum(rate(user_logins_total{result="failure"}[5m]))
+            /
+            sum(rate(user_logins_total[5m]))
+          ) > 0.3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High login failure rate"
+          description: >-
+            Login failure rate exceeds 30% over the last 5 minutes
+            (current: {{ $value | humanizePercentage }}).
+            Possible brute-force attack or authentication issue.

--- a/infrastructure/monitoring/prometheus/alerts/resources.yml
+++ b/infrastructure/monitoring/prometheus/alerts/resources.yml
@@ -1,0 +1,112 @@
+# ============================================================================
+# Resource Alert Rules
+# ============================================================================
+# Alerts for disk space, memory, and connection pool exhaustion.
+
+groups:
+  - name: resources
+    rules:
+      # ------------------------------------------------------------------
+      # Prometheus Storage (Disk Space)
+      # ------------------------------------------------------------------
+
+      - alert: PrometheusStorageHigh
+        expr: >-
+          (prometheus_tsdb_storage_blocks_bytes / 1024 / 1024 / 1024) > 10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus storage exceeds 10 GB"
+          description: >-
+            Prometheus TSDB storage is using {{ $value | humanize1024 }}B.
+            Consider reducing retention or adding disk space.
+
+      # ------------------------------------------------------------------
+      # Database Connection Pool
+      # ------------------------------------------------------------------
+
+      - alert: DbConnectionPoolExhaustion
+        expr: >-
+          db_connections_active
+          /
+          (db_connections_active + db_connections_idle)
+          > 0.85
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database connection pool near exhaustion"
+          description: >-
+            Active database connections exceed 85% of the total pool
+            (active: {{ $value | humanizePercentage }}).
+            The pool may soon be exhausted.
+
+      - alert: DbConnectionPoolFull
+        expr: db_connections_idle == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database connection pool fully exhausted"
+          description: >-
+            There are zero idle database connections for the last 2 minutes.
+            New queries may be blocked waiting for a connection.
+
+      # ------------------------------------------------------------------
+      # Redis Memory
+      # ------------------------------------------------------------------
+
+      - alert: RedisHighMemory
+        expr: redis_memory_used_bytes / redis_memory_max_bytes > 0.85
+        for: 5m
+        labels:
+          severity: warning
+          service: redis
+        annotations:
+          summary: "Redis memory usage above 85%"
+          description: >-
+            Redis memory usage is {{ $value | humanizePercentage }} of the
+            configured maximum. Evictions may start soon.
+
+      - alert: CacheMemoryHigh
+        expr: cache_memory_usage_bytes > 500 * 1024 * 1024
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Application cache memory exceeds 500 MB"
+          description: >-
+            Application-level cache memory is using
+            {{ $value | humanize1024 }}B.
+
+      # ------------------------------------------------------------------
+      # PostgreSQL Replication Lag (for future HA setups)
+      # ------------------------------------------------------------------
+
+      - alert: PostgresReplicationLag
+        expr: pg_replication_lag > 30
+        for: 5m
+        labels:
+          severity: warning
+          service: postgres
+        annotations:
+          summary: "PostgreSQL replication lag > 30s"
+          description: >-
+            Replication lag is {{ $value | humanizeDuration }}.
+            Read replicas may be serving stale data.
+
+      # ------------------------------------------------------------------
+      # Too Many WebSocket Connections
+      # ------------------------------------------------------------------
+
+      - alert: HighWebSocketConnections
+        expr: websocket_connections_active > 500
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High number of active WebSocket connections"
+          description: >-
+            There are {{ $value }} active WebSocket connections.
+            This may indicate abnormal client behavior or a connection leak.

--- a/infrastructure/monitoring/prometheus/alerts/service_health.yml
+++ b/infrastructure/monitoring/prometheus/alerts/service_health.yml
@@ -1,0 +1,101 @@
+# ============================================================================
+# Service Health Alert Rules
+# ============================================================================
+# Alerts for service availability and basic health checks.
+
+groups:
+  - name: service_health
+    rules:
+      # ------------------------------------------------------------------
+      # Target Down
+      # ------------------------------------------------------------------
+
+      - alert: ServiceDown
+        expr: up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "{{ $labels.job }} is down"
+          description: >-
+            {{ $labels.job }} (instance {{ $labels.instance }}) has been
+            unreachable for more than 1 minute.
+
+      # ------------------------------------------------------------------
+      # Backend API Health
+      # ------------------------------------------------------------------
+
+      - alert: BackendApiDown
+        expr: up{job="backend"} == 0
+        for: 30s
+        labels:
+          severity: critical
+          service: backend
+        annotations:
+          summary: "Backend API is down"
+          description: >-
+            The FastAPI backend has been unreachable for more than 30 seconds.
+            Immediate investigation required.
+
+      # ------------------------------------------------------------------
+      # PostgreSQL Down
+      # ------------------------------------------------------------------
+
+      - alert: PostgresDown
+        expr: up{job="postgres"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: postgres
+        annotations:
+          summary: "PostgreSQL exporter is down"
+          description: >-
+            The postgres-exporter has been unreachable for more than 1 minute.
+            Database may be unavailable.
+
+      # ------------------------------------------------------------------
+      # Redis Down
+      # ------------------------------------------------------------------
+
+      - alert: RedisDown
+        expr: up{job="redis"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: redis
+        annotations:
+          summary: "Redis exporter is down"
+          description: >-
+            The redis-exporter has been unreachable for more than 1 minute.
+            Cache layer may be unavailable.
+
+      # ------------------------------------------------------------------
+      # Nginx Down
+      # ------------------------------------------------------------------
+
+      - alert: NginxDown
+        expr: up{job="nginx"} == 0
+        for: 1m
+        labels:
+          severity: critical
+          service: nginx
+        annotations:
+          summary: "Nginx exporter is down"
+          description: >-
+            The nginx-exporter has been unreachable for more than 1 minute.
+            Reverse proxy may be unavailable.
+
+      # ------------------------------------------------------------------
+      # Prometheus Configuration Reload Failure
+      # ------------------------------------------------------------------
+
+      - alert: PrometheusConfigReloadFailed
+        expr: prometheus_config_last_reload_successful != 1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prometheus configuration reload failed"
+          description: >-
+            Prometheus failed to reload its configuration.
+            Check for syntax errors in prometheus.yml or alert rules.

--- a/infrastructure/monitoring/prometheus/prometheus.yml
+++ b/infrastructure/monitoring/prometheus/prometheus.yml
@@ -13,16 +13,16 @@ global:
 # Retain data for 15 days (default is 15d anyway)
 # --storage.tsdb.retention.time=15d (set in docker-compose)
 
-# Alertmanager configuration (optional)
-# alerting:
-#   alertmanagers:
-#     - static_configs:
-#         - targets:
-#             - alertmanager:9093
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
 
 # Rule files
 rule_files:
-  # - "alerts/*.yml"
+  - "alerts/*.yml"
 
 # Scrape configurations
 scrape_configs:


### PR DESCRIPTION
## Summary
- Create Prometheus alerting rule files for service health, performance, and resource monitoring
- Add Alertmanager configuration with webhook receiver, routing, and inhibition rules
- Update `prometheus.yml` to enable alerting and load rule files
- Add alertmanager container to `docker-compose.yml` with monitoring profile

## Changes

### New Files
- `infrastructure/monitoring/prometheus/alerts/service_health.yml` — Service availability alerts (ServiceDown, BackendApiDown, PostgresDown, RedisDown, NginxDown, PrometheusConfigReloadFailed)
- `infrastructure/monitoring/prometheus/alerts/performance.yml` — Performance alerts (HighErrorRate, HighLatencyP95/P99, HighSlowQueryRate, DatabaseQueryErrors, LowCacheHitRatio, HighLoginFailureRate)
- `infrastructure/monitoring/prometheus/alerts/resources.yml` — Resource alerts (PrometheusStorageHigh, DbConnectionPoolExhaustion/Full, RedisHighMemory, CacheMemoryHigh, PostgresReplicationLag, HighWebSocketConnections)
- `infrastructure/monitoring/alertmanager/alertmanager.yml` — Alertmanager routing, grouping, inhibition, and receiver configuration

### Modified Files
- `infrastructure/monitoring/prometheus/prometheus.yml` — Enable alerting section and rule_files glob
- `docker-compose.yml` — Add alerts volume mount to prometheus; add alertmanager container

## Test plan
- [ ] Verify `docker compose --profile monitoring config` parses without errors
- [ ] Verify Prometheus starts and loads alert rules without errors (`/api/v1/rules`)
- [ ] Verify Alertmanager starts and is reachable on port 9093
- [ ] Verify alert rule expressions match metric names defined in `backend/app/core/metrics.py`
- [ ] Verify inhibition rules suppress warnings when critical fires for same service

Closes #513