### PR TITLE
feat(infra): add celery exporter and monitoring documentation (#478)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -378,6 +378,19 @@ services:
     networks:
       - screener_network
 
+  celery-exporter:
+    profiles: ["monitoring", "full"]
+    image: danihodovic/celery-exporter:latest
+    container_name: screener_celery_exporter
+    restart: unless-stopped
+    environment:
+      CE_BROKER_URL: redis://:${REDIS_PASSWORD:?REDIS_PASSWORD environment variable is required}@redis:6379/1
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - screener_network
+
 # ============================================================================
 # VOLUMES
 # ============================================================================

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -1,0 +1,214 @@
+# Monitoring Setup
+
+This document describes the monitoring infrastructure for the Stock Screening Platform.
+
+## Architecture Overview
+
+```
+┌──────────────┐     scrape      ┌──────────────┐     alert      ┌───────────────┐
+│  Prometheus  │ ◄────────────── │  Exporters   │                │  Alertmanager │
+│  :9090       │ ──────────────► │              │                │  :9093        │
+└──────┬───────┘   evaluate      └──────────────┘                └───────┬───────┘
+       │           rules                                                 │
+       │                                                          route/notify
+       ▼                                                                 │
+┌──────────────┐                                                         ▼
+│   Grafana    │                                                 ┌───────────────┐
+│   :3001      │                                                 │  Webhook /    │
+└──────────────┘                                                 │  Slack / Email│
+                                                                 └───────────────┘
+```
+
+## Quick Start
+
+### Start monitoring services
+
+```bash
+# Start core services + monitoring
+docker compose --profile monitoring up -d
+
+# Start everything (includes celery, airflow, frontend, monitoring)
+docker compose --profile full up -d
+```
+
+### Access dashboards
+
+| Service       | URL                          | Default Credentials         |
+|---------------|------------------------------|-----------------------------|
+| Grafana       | http://localhost:3001        | `$GRAFANA_USER` / `$GRAFANA_PASSWORD` |
+| Prometheus    | http://localhost:9090        | No authentication           |
+| Alertmanager  | http://localhost:9093        | No authentication           |
+
+## Components
+
+### Prometheus (Metrics Collection)
+
+- **Image**: `prom/prometheus:latest`
+- **Port**: 9090
+- **Retention**: 15 days
+- **Scrape interval**: 15s (global), 10s (backend), 30s (exporters)
+- **Config**: `infrastructure/monitoring/prometheus/prometheus.yml`
+
+### Grafana (Visualization)
+
+- **Image**: `grafana/grafana:latest`
+- **Port**: 3001 (mapped from container 3000)
+- **Datasource**: Prometheus (auto-provisioned)
+- **Dashboards**: Auto-provisioned from `infrastructure/monitoring/grafana/dashboards/json/`
+
+### Alertmanager (Alert Routing)
+
+- **Image**: `prom/alertmanager:latest`
+- **Port**: 9093
+- **Config**: `infrastructure/monitoring/alertmanager/alertmanager.yml`
+- **Default receiver**: Webhook to `backend:8000/v1/webhooks/alertmanager`
+
+## Exporters
+
+| Exporter          | Image                                        | Metrics Port | Target Service |
+|-------------------|----------------------------------------------|-------------|----------------|
+| postgres-exporter | `prometheuscommunity/postgres-exporter`      | 9187        | PostgreSQL     |
+| redis-exporter    | `oliver006/redis_exporter`                   | 9121        | Redis          |
+| nginx-exporter    | `nginx/nginx-prometheus-exporter`            | 9113        | Nginx          |
+| celery-exporter   | `danihodovic/celery-exporter`                | 9808        | Celery Worker  |
+
+All exporters run under the `monitoring` or `full` Docker Compose profile.
+
+### Nginx Exporter Prerequisites
+
+The nginx-exporter requires `stub_status` to be enabled. This is already configured in
+`infrastructure/nginx/nginx.conf` on port 8081:
+
+```nginx
+server {
+    listen 8081;
+    location /stub_status {
+        stub_status;
+    }
+}
+```
+
+## Dashboards
+
+Four pre-built Grafana dashboards are auto-provisioned:
+
+| Dashboard              | File                        | Key Metrics                                         |
+|------------------------|-----------------------------|-----------------------------------------------------|
+| API Performance        | `api_performance.json`      | Request rate, latency (p50/p95/p99), error rate     |
+| Business Metrics       | `business_metrics.json`     | Active users, logins, registrations, screenings     |
+| Cache Performance      | `cache_performance.json`    | Hit ratio, operations, memory usage                 |
+| Database Performance   | `database_performance.json` | Query duration, connections, slow queries, errors   |
+
+## Alert Rules
+
+Alert rules are defined in `infrastructure/monitoring/prometheus/alerts/`:
+
+| File                  | Alerts                                                                      |
+|-----------------------|-----------------------------------------------------------------------------|
+| `service_health.yml`  | ServiceDown, BackendApiDown, PostgresDown, RedisDown, NginxDown             |
+| `performance.yml`     | HighErrorRate, HighLatencyP95/P99, SlowQueries, LowCacheHitRatio           |
+| `resources.yml`       | PrometheusStorageHigh, DbConnectionPoolExhaustion, RedisHighMemory         |
+
+### Severity Levels
+
+- **critical**: Immediate attention required (1h repeat interval)
+- **warning**: Investigation needed (4h repeat interval)
+
+### Inhibition Rules
+
+When a `critical` alert fires, the corresponding `warning` alert for the same service
+is automatically suppressed to reduce noise.
+
+## Application Metrics
+
+The backend exposes Prometheus metrics at `GET /metrics`. All metrics are defined in
+`backend/app/core/metrics.py`:
+
+### HTTP Metrics
+- `http_requests_total` — Total requests by method, endpoint, status_code
+- `http_request_duration_seconds` — Request duration histogram
+- `http_requests_in_progress` — Currently processing requests
+- `http_errors_total` — 5xx error count
+
+### Database Metrics
+- `db_query_duration_seconds` — Query duration by operation and table
+- `db_connections_active` / `db_connections_idle` — Connection pool status
+- `db_slow_queries_total` — Queries exceeding 1 second
+- `db_query_errors_total` — Query error count by type
+
+### Cache Metrics
+- `cache_operations_total` — Cache operations by result (hit/miss)
+- `cache_hit_ratio` — Calculated hit ratio (0.0-1.0)
+- `cache_operation_duration_seconds` — Cache operation latency
+- `cache_memory_usage_bytes` — Redis memory usage
+
+### Business Metrics
+- `user_registrations_total` / `user_logins_total` — User activity
+- `screening_requests_total` — Screening request count by template
+- `screening_results_count` — Results per screening histogram
+- `active_users_current` — Currently active users
+- `websocket_connections_active` — Active WebSocket connections
+
+## Notification Channels
+
+The default Alertmanager configuration uses a webhook receiver. To enable other channels,
+edit `infrastructure/monitoring/alertmanager/alertmanager.yml`:
+
+### Slack
+
+```yaml
+receivers:
+  - name: 'slack-critical'
+    slack_configs:
+      - api_url: '${ALERTMANAGER_SLACK_WEBHOOK_URL}'
+        channel: '#alerts-critical'
+        send_resolved: true
+```
+
+### Email
+
+```yaml
+receivers:
+  - name: 'email-critical'
+    email_configs:
+      - to: '${ALERTMANAGER_EMAIL_TO}'
+        from: '${SMTP_FROM}'
+        smarthost: '${SMTP_SMARTHOST}'
+        require_tls: true
+        send_resolved: true
+```
+
+## Environment Variables
+
+| Variable                         | Required | Description                          |
+|----------------------------------|----------|--------------------------------------|
+| `GRAFANA_USER`                   | No       | Grafana admin username (default: admin) |
+| `GRAFANA_PASSWORD`               | Yes      | Grafana admin password               |
+| `PROMETHEUS_PORT`                | No       | Prometheus port (default: 9090)      |
+| `GRAFANA_PORT`                   | No       | Grafana port (default: 3001)         |
+| `ALERTMANAGER_PORT`              | No       | Alertmanager port (default: 9093)    |
+| `ALERTMANAGER_SLACK_WEBHOOK_URL` | No       | Slack webhook URL for alerts         |
+| `ALERTMANAGER_EMAIL_TO`          | No       | Alert recipient email                |
+| `SMTP_SMARTHOST`                 | No       | SMTP relay host:port                 |
+| `SMTP_FROM`                      | No       | Alert sender email address           |
+
+## Future Enhancements
+
+### Airflow Metrics
+
+Airflow requires a StatsD exporter to expose metrics in Prometheus format.
+To enable Airflow monitoring:
+
+1. Add `statsd-exporter` container to `docker-compose.yml`
+2. Set Airflow environment variables:
+   ```yaml
+   AIRFLOW__METRICS__STATSD_ON: 'true'
+   AIRFLOW__METRICS__STATSD_HOST: statsd-exporter
+   AIRFLOW__METRICS__STATSD_PORT: 9125
+   ```
+3. Uncomment the `airflow` scrape config in `prometheus.yml`
+
+### Node Exporter (System Metrics)
+
+For host-level metrics (CPU, memory, disk), add `node-exporter` container
+and uncomment the corresponding scrape config in `prometheus.yml`.

--- a/infrastructure/monitoring/prometheus/prometheus.yml
+++ b/infrastructure/monitoring/prometheus/prometheus.yml
@@ -88,17 +88,15 @@ scrape_configs:
   # ============================================================================
   # CELERY WORKERS
   # ============================================================================
-  # Celery does not natively expose Prometheus metrics.
-  # Uncomment and configure when a celery-exporter or Flower with metrics is deployed.
 
-  # - job_name: 'celery'
-  #   scrape_interval: 30s
-  #   metrics_path: '/metrics'
-  #   static_configs:
-  #     - targets: ['celery-exporter:9808']
-  #       labels:
-  #         service: 'celery-worker'
-  #         tier: 'background-jobs'
+  - job_name: 'celery'
+    scrape_interval: 30s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['celery-exporter:9808']
+        labels:
+          service: 'celery-worker'
+          tier: 'background-jobs'
 
   # ============================================================================
   # AIRFLOW


### PR DESCRIPTION
## Summary
- Add celery-exporter container (`danihodovic/celery-exporter`) to docker-compose monitoring profile
- Enable celery scrape target in Prometheus configuration
- Create comprehensive monitoring documentation (`docs/MONITORING.md`)

## Context

This PR completes the remaining items from #478. Previous PRs already addressed:
- PR #515: Added postgres-exporter, redis-exporter, nginx-exporter containers
- PR #539: Added alerting rules, Alertmanager configuration, enabled rule_files

## Changes

### docker-compose.yml
- Add `celery-exporter` service under `monitoring` and `full` profiles
- Connects to Redis broker (channel 1) to discover Celery tasks and workers

### prometheus.yml
- Uncomment celery scrape config targeting `celery-exporter:9808`

### docs/MONITORING.md (New)
- Architecture overview with component diagram
- Quick start instructions for monitoring services
- Exporter reference table with images and ports
- Dashboard descriptions and metric references
- Alert rules summary with severity levels
- Complete application metrics catalog (19 metrics)
- Notification channel configuration examples (Slack, email)
- Environment variable reference
- Future enhancement notes (Airflow StatsD, Node Exporter)

## Test plan
- [ ] Verify `docker compose --profile monitoring config` parses without errors
- [ ] Verify celery-exporter starts and connects to Redis broker
- [ ] Verify Prometheus scrapes celery-exporter metrics at `:9808/metrics`
- [ ] Verify monitoring documentation renders correctly on GitHub

Closes #478