### PR TITLE
fix(ci): enable coverage gate and add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
+    hooks:
+      - id: black
+        name: black (backend)
+        files: ^backend/
+        language_version: python3.11
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (backend)
+        files: ^backend/
+        args: ["--settings-path=backend/pyproject.toml"]
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+        name: flake8 (backend)
+        files: ^backend/
+        args: ["--max-line-length=100", "--extend-ignore=E203,W503"]
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        name: prettier (frontend)
+        files: ^frontend/src/.*\.(js|jsx|ts|tsx|css)$
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-merge-conflict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,105 @@
+# Contributing Guide
+
+## Code Quality Standards
+
+All code must pass the following quality gates before merging. These same checks run in CI
+and will **block merges** if they fail.
+
+## Quick Start
+
+### Install pre-commit hooks (recommended)
+
+Pre-commit hooks automatically run quality checks before each commit, catching issues early.
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+After installation, hooks run automatically on `git commit`. To run all hooks manually:
+
+```bash
+pre-commit run --all-files
+```
+
+---
+
+## Backend (Python)
+
+### Setup
+
+```bash
+cd backend
+pip install -r requirements.txt
+pip install black flake8 mypy isort
+```
+
+### Checks
+
+| Tool | Command | What it checks |
+|------|---------|----------------|
+| black | `black --check .` | Code formatting |
+| isort | `isort --check-only .` | Import ordering |
+| flake8 | `flake8 app tests --max-line-length=100 --extend-ignore=E203,W503` | Linting |
+| mypy | `mypy app --ignore-missing-imports` | Type checking |
+| pytest | `pytest` | Tests + ≥65% coverage |
+
+### Auto-fix formatting
+
+```bash
+cd backend
+black .
+isort .
+```
+
+### Run tests with coverage
+
+```bash
+cd backend
+pytest
+# Coverage report: htmlcov/index.html
+```
+
+The minimum coverage threshold is **65%**. PRs that drop coverage below this threshold
+will fail CI.
+
+---
+
+## Frontend (TypeScript/React)
+
+### Setup
+
+```bash
+cd frontend
+npm ci
+```
+
+### Checks
+
+| Tool | Command | What it checks |
+|------|---------|----------------|
+| ESLint | `npm run lint` | Linting |
+| Prettier | `npx prettier --check "src/**/*.{js,jsx,ts,tsx,css,md}"` | Formatting |
+| TypeScript | `npm run type-check` | Type checking |
+| Vitest | `npm test -- --run` | Unit tests |
+
+### Auto-fix formatting
+
+```bash
+cd frontend
+npx prettier --write "src/**/*.{js,jsx,ts,tsx,css,md}"
+npm run lint -- --fix
+```
+
+---
+
+## CI Pipeline
+
+The following jobs must all pass before a PR can be merged:
+
+- **backend-lint** — black, isort, flake8, mypy
+- **backend-test** — pytest with ≥65% coverage gate
+- **frontend-lint** — ESLint, Prettier
+- **frontend-test** — TypeScript check + Vitest
+
+Run these locally before pushing to avoid CI round-trips.

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -11,7 +11,7 @@ addopts =
     --cov-report=term-missing
     --cov-report=html
     --cov-report=xml
-    # --cov-fail-under=59  # Temporarily disabled, will be set to 80 in TECH-DEBT-008
+    --cov-fail-under=65
 markers =
     unit: Unit tests
     integration: Integration tests


### PR DESCRIPTION
## What

- Enable `--cov-fail-under=65` in `backend/pytest.ini` to block merges when coverage drops
- Add `.pre-commit-config.yaml` with black, isort, flake8, prettier, and general hooks
- Add `CONTRIBUTING.md` documenting all quality checks and how to run them locally

## Why

Closes #475

Quality gates were non-blocking (`continue-on-error: true` has since been removed from CI
lint steps). The missing piece was the coverage threshold in `pytest.ini` and local
developer tooling to catch issues before pushing.

## How

### Test Plan
- CI `backend-lint` and `frontend-lint` jobs are already blocking (no `continue-on-error`)
- `backend-test` now enforces ≥65% coverage via `--cov-fail-under=65`
- `pre-commit run --all-files` can be used locally to verify all checks pass